### PR TITLE
既存のsuiネットワークとの同期機能追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,8 @@
       "Bash(npm run dev:*)",
       "Bash(sui:*)",
       "Bash(timeout:*)",
-      "Bash(gtimeout:*)"
+      "Bash(gtimeout:*)",
+      "Bash(npm run build:*)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,8 @@
       "Bash(sui:*)",
       "Bash(timeout:*)",
       "Bash(gtimeout:*)",
-      "Bash(npm run build:*)"
+      "Bash(npm run build:*)",
+      "Bash(grep:*)"
     ],
     "deny": []
   }

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -18,6 +18,20 @@ export class IPCHandlers {
     this.configService = configService
     this.logService = logService
     this.setupHandlers()
+    this.loadInitialSettings()
+  }
+
+  private async loadInitialSettings(): Promise<void> {
+    try {
+      const settings = await this.configService.getSettings()
+      
+      // SUIパスの設定
+      if (settings.suiPath) {
+        this.suiService.setSuiPath(settings.suiPath)
+      }
+    } catch (error) {
+      this.logService.logApp('error', `Failed to load initial settings: ${error}`)
+    }
   }
 
   private setupHandlers(): void {
@@ -81,6 +95,93 @@ export class IPCHandlers {
           version: '',
           path: '',
         }
+      }
+    })
+
+    ipcMain.handle('sui:detectExistingNetwork', async () => {
+      try {
+        const result = await this.suiService.detectExistingNetwork()
+        this.logService.logApp('info', `Existing network detection: ${result.found ? 'found' : 'not found'}`)
+        return result
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+        this.logService.logApp('error', `Existing network detection error: ${errorMessage}`)
+        return { found: false, processes: [] }
+      }
+    })
+
+    ipcMain.handle('sui:getProcessStatus', async (_, pid) => {
+      try {
+        return await this.suiService.getProcessStatus(pid)
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+        this.logService.logApp('error', `Process status check error: ${errorMessage}`)
+        return { running: false }
+      }
+    })
+
+    ipcMain.handle('sui:killProcess', async (_, pid) => {
+      try {
+        const result = await this.suiService.killProcess(pid)
+        if (result.success) {
+          this.logService.logApp('info', `Process ${pid} terminated successfully`)
+        } else {
+          this.logService.logApp('error', `Failed to terminate process ${pid}: ${result.message}`)
+        }
+        return result
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+        this.logService.logApp('error', `Process termination error: ${errorMessage}`)
+        return { success: false, message: errorMessage }
+      }
+    })
+
+    ipcMain.handle('sui:killAllProcesses', async () => {
+      try {
+        const result = await this.suiService.killAllExistingProcesses()
+        if (result.success) {
+          this.logService.logApp('info', `All processes terminated: ${result.message}`)
+        } else {
+          this.logService.logApp('error', `Failed to terminate all processes: ${result.message}`)
+        }
+        return result
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+        this.logService.logApp('error', `Bulk termination error: ${errorMessage}`)
+        return { success: false, message: errorMessage, results: [] }
+      }
+    })
+
+    ipcMain.handle('sui:verifyNetworkConnection', async (_, port) => {
+      try {
+        const result = await this.suiService.verifyNetworkConnection(port)
+        this.logService.logApp('info', `Network verification: ${result.message}`)
+        return result
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+        this.logService.logApp('error', `Network verification error: ${errorMessage}`)
+        return {
+          connected: false,
+          rpcReady: false,
+          clientReady: false,
+          message: errorMessage
+        }
+      }
+    })
+
+    ipcMain.handle('sui:syncWithExistingNetwork', async () => {
+      try {
+        const result = await this.suiService.syncWithExistingNetworkManually()
+        if (result.success) {
+          this.logService.logApp('info', `Network sync success: ${result.message}`)
+        } else {
+          this.logService.logApp('warn', `Network sync failed: ${result.message}`)
+        }
+        return result
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+        this.logService.logApp('error', `Network sync error: ${errorMessage}`)
+        return { success: false, message: errorMessage }
       }
     })
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -96,6 +96,17 @@ export class IPCHandlers {
       return this.suiService.getStatus()
     })
 
+    ipcMain.handle('sui:updateNetworkStatus', async (_, port) => {
+      try {
+        await this.suiService.updateNetworkStatus(port || '9000')
+        return { success: true }
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+        this.logService.logApp('error', `Network status update error: ${errorMessage}`)
+        return { success: false, message: errorMessage }
+      }
+    })
+
     ipcMain.handle('sui:checkInstallation', async () => {
       try {
         this.ensureReady()

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -8,6 +8,7 @@ export class IPCHandlers {
   private configService: ConfigService
   private logService: LogService
   private mainWindow: Electron.BrowserWindow | null = null
+  private isReady: boolean = false
 
   constructor(
     suiService: SuiService,
@@ -18,7 +19,17 @@ export class IPCHandlers {
     this.configService = configService
     this.logService = logService
     this.setupHandlers()
-    this.loadInitialSettings()
+  }
+
+  async initialize(): Promise<void> {
+    await this.loadInitialSettings()
+    this.isReady = true
+  }
+
+  private ensureReady(): void {
+    if (!this.isReady) {
+      throw new Error('IPC handlers not initialized. Call initialize() first.')
+    }
   }
 
   private async loadInitialSettings(): Promise<void> {
@@ -38,6 +49,7 @@ export class IPCHandlers {
     // SUI関連のハンドラー
     ipcMain.handle('sui:start', async () => {
       try {
+        this.ensureReady()
         const activeProfile = await this.configService.getActiveProfile()
         const config = activeProfile ? {
           port: activeProfile.port,
@@ -86,6 +98,7 @@ export class IPCHandlers {
 
     ipcMain.handle('sui:checkInstallation', async () => {
       try {
+        this.ensureReady()
         return await this.suiService.checkInstallation()
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error'
@@ -232,6 +245,7 @@ export class IPCHandlers {
 
     ipcMain.handle('config:saveSettings', async (_, settings) => {
       try {
+        this.ensureReady()
         const result = await this.configService.saveSettings(settings)
         if (result.success) {
           this.logService.logApp('info', 'Settings saved successfully')

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -173,6 +173,7 @@ async function initializeServices(): Promise<void> {
 
     // IPCハンドラーを初期化
     ipcHandlers = new IPCHandlers(suiService, configService, logService)
+    await ipcHandlers.initialize()
     ipcHandlers.setupServiceEvents(mainWindow)
 
     logService.logApp('info', 'Application services initialized successfully')

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -8,6 +8,12 @@ const electronAPI = {
     stop: () => ipcRenderer.invoke('sui:stop'),
     getStatus: () => ipcRenderer.invoke('sui:getStatus'),
     checkInstallation: () => ipcRenderer.invoke('sui:checkInstallation'),
+    detectExistingNetwork: () => ipcRenderer.invoke('sui:detectExistingNetwork'),
+    getProcessStatus: (pid: number) => ipcRenderer.invoke('sui:getProcessStatus', pid),
+    killProcess: (pid: number) => ipcRenderer.invoke('sui:killProcess', pid),
+    killAllProcesses: () => ipcRenderer.invoke('sui:killAllProcesses'),
+    verifyNetworkConnection: (port?: string) => ipcRenderer.invoke('sui:verifyNetworkConnection', port),
+    syncWithExistingNetwork: () => ipcRenderer.invoke('sui:syncWithExistingNetwork'),
     
     // イベントリスナー
     onStatusChange: (callback: (status: any) => void) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -7,6 +7,7 @@ const electronAPI = {
     start: () => ipcRenderer.invoke('sui:start'),
     stop: () => ipcRenderer.invoke('sui:stop'),
     getStatus: () => ipcRenderer.invoke('sui:getStatus'),
+    updateNetworkStatus: (port?: string) => ipcRenderer.invoke('sui:updateNetworkStatus', port),
     checkInstallation: () => ipcRenderer.invoke('sui:checkInstallation'),
     detectExistingNetwork: () => ipcRenderer.invoke('sui:detectExistingNetwork'),
     getProcessStatus: (pid: number) => ipcRenderer.invoke('sui:getProcessStatus', pid),

--- a/src/main/services/SuiService.ts
+++ b/src/main/services/SuiService.ts
@@ -105,44 +105,156 @@ export class SuiService extends EventEmitter {
 
   async checkExistingProcesses(): Promise<{ processes: Array<{ pid: number; command: string; port?: string }> }> {
     try {
-      const { spawn } = await import('child_process')
+      // Try platform-specific approach first (pgrep for Unix-like systems)
+      const processes = await this.findProcessesWithPgrep()
+      if (processes.length > 0) {
+        return { processes }
+      }
       
-      return new Promise((resolve) => {
-        const psProcess = spawn('ps', ['aux'], { stdio: 'pipe' })
-        let output = ''
-        
-        psProcess.stdout?.on('data', (data) => {
-          output += data.toString()
-        })
-        
-        psProcess.on('close', () => {
-          const lines = output.split('\n')
-          const suiProcesses = lines
-            .filter(line => line.includes('sui start') || line.includes('sui-test-validator'))
-            .map(line => {
-              const parts = line.trim().split(/\s+/)
-              const pid = parseInt(parts[1])
-              const command = parts.slice(10).join(' ')
-              
-              // ポート番号を抽出
-              const portMatch = command.match(/--fullnode-rpc-port\s+(\d+)|--port\s+(\d+)/)
-              const port = portMatch ? (portMatch[1] || portMatch[2]) : undefined
-              
-              return { pid, command, port }
-            })
-            .filter(process => !isNaN(process.pid))
-          
-          resolve({ processes: suiProcesses })
-        })
-        
-        psProcess.on('error', () => {
-          resolve({ processes: [] })
-        })
-      })
+      // Fallback to regex-based ps parsing if pgrep fails
+      return await this.findProcessesWithPs()
     } catch (error) {
       this.emit('log', { level: 'error', message: `プロセス検出エラー: ${error instanceof Error ? error.message : 'Unknown error'}` })
       return { processes: [] }
     }
+  }
+
+  private async findProcessesWithPgrep(): Promise<Array<{ pid: number; command: string; port?: string }>> {
+    const { spawn } = await import('child_process')
+    
+    try {
+      // Use pgrep to find PIDs, then get full command lines
+      const suiPatterns = ['sui start', 'sui-test-validator']
+      const allProcesses: Array<{ pid: number; command: string; port?: string }> = []
+      
+      for (const pattern of suiPatterns) {
+        const pids = await this.getPidsWithPgrep(pattern)
+        
+        for (const pid of pids) {
+          const command = await this.getCommandForPid(pid)
+          if (command) {
+            const port = this.extractPortFromCommand(command)
+            allProcesses.push({ pid, command, port })
+          }
+        }
+      }
+      
+      return allProcesses
+    } catch (error) {
+      this.emit('log', { level: 'debug', message: `pgrep方式でのプロセス検出に失敗: ${error instanceof Error ? error.message : 'Unknown error'}` })
+      return []
+    }
+  }
+
+  private async getPidsWithPgrep(pattern: string): Promise<number[]> {
+    const { spawn } = await import('child_process')
+    
+    return new Promise((resolve, reject) => {
+      const pgrepProcess = spawn('pgrep', ['-f', pattern], { stdio: 'pipe' })
+      let output = ''
+      
+      pgrepProcess.stdout?.on('data', (data) => {
+        output += data.toString()
+      })
+      
+      pgrepProcess.on('close', (code) => {
+        if (code === 0 && output.trim()) {
+          const pids = output.trim().split('\n')
+            .map(pid => parseInt(pid.trim()))
+            .filter(pid => !isNaN(pid))
+          resolve(pids)
+        } else {
+          resolve([])
+        }
+      })
+      
+      pgrepProcess.on('error', (error) => {
+        reject(error)
+      })
+    })
+  }
+
+  private async getCommandForPid(pid: number): Promise<string | null> {
+    const { spawn } = await import('child_process')
+    
+    return new Promise((resolve) => {
+      const psProcess = spawn('ps', ['-p', pid.toString(), '-o', 'command='], { stdio: 'pipe' })
+      let output = ''
+      
+      psProcess.stdout?.on('data', (data) => {
+        output += data.toString()
+      })
+      
+      psProcess.on('close', (code) => {
+        if (code === 0 && output.trim()) {
+          resolve(output.trim())
+        } else {
+          resolve(null)
+        }
+      })
+      
+      psProcess.on('error', () => {
+        resolve(null)
+      })
+    })
+  }
+
+  private async findProcessesWithPs(): Promise<{ processes: Array<{ pid: number; command: string; port?: string }> }> {
+    const { spawn } = await import('child_process')
+    
+    return new Promise((resolve) => {
+      // Use ps with specific format to get PID and command
+      const psProcess = spawn('ps', ['axo', 'pid,command'], { stdio: 'pipe' })
+      let output = ''
+      
+      psProcess.stdout?.on('data', (data) => {
+        output += data.toString()
+      })
+      
+      psProcess.on('close', () => {
+        const processes = this.parseProcessLines(output)
+        resolve({ processes })
+      })
+      
+      psProcess.on('error', () => {
+        resolve({ processes: [] })
+      })
+    })
+  }
+
+  private parseProcessLines(output: string): Array<{ pid: number; command: string; port?: string }> {
+    const lines = output.split('\n')
+    const suiProcesses: Array<{ pid: number; command: string; port?: string }> = []
+    
+    for (const line of lines) {
+      const trimmedLine = line.trim()
+      if (!trimmedLine || trimmedLine.startsWith('PID')) {
+        continue
+      }
+      
+      // Use regex to extract PID and command more reliably
+      const match = trimmedLine.match(/^(\d+)\s+(.+)$/)
+      if (!match) {
+        continue
+      }
+      
+      const pid = parseInt(match[1])
+      const command = match[2]
+      
+      // Check if this is a SUI process
+      if ((command.includes('sui start') || command.includes('sui-test-validator')) && !isNaN(pid)) {
+        const port = this.extractPortFromCommand(command)
+        suiProcesses.push({ pid, command, port })
+      }
+    }
+    
+    return suiProcesses
+  }
+
+  private extractPortFromCommand(command: string): string | undefined {
+    // Extract port number from command line arguments
+    const portMatch = command.match(/--fullnode-rpc-port\s+(\d+)|--port\s+(\d+)|--rpc-port\s+(\d+)/)
+    return portMatch ? (portMatch[1] || portMatch[2] || portMatch[3]) : undefined
   }
 
   async getProcessStatus(pid: number): Promise<{ running: boolean; details?: any }> {

--- a/src/main/services/SuiService.ts
+++ b/src/main/services/SuiService.ts
@@ -33,17 +33,22 @@ export class SuiService extends EventEmitter {
   }
 
   async checkInstallation(): Promise<SuiInstallation> {
+    this.emit('log', { level: 'info', message: 'SUIインストール確認開始' })
+    
     // 設定されたパスを最初に確認
     if (this.suiPath) {
+      this.emit('log', { level: 'info', message: `設定済みパスを確認中: ${this.suiPath}` })
       try {
         await fs.access(this.suiPath)
         const version = await this.getSuiVersion(this.suiPath)
+        this.emit('log', { level: 'info', message: `SUI確認完了 - パス: ${this.suiPath}, バージョン: ${version}` })
         return {
           installed: true,
           version,
           path: this.suiPath,
         }
       } catch (error) {
+        this.emit('log', { level: 'warn', message: `設定パスでSUI実行ファイルが見つかりません: ${this.suiPath}` })
         // 設定されたパスが無効な場合は自動検出に進む
       }
     }
@@ -55,21 +60,28 @@ export class SuiService extends EventEmitter {
       path.join(process.env.HOME || '', '.cargo/bin/sui'),
     ]
 
+    this.emit('log', { level: 'info', message: '一般的なパスでSUIを検索中...' })
+    
     for (const suiPath of possiblePaths) {
+      this.emit('log', { level: 'info', message: `パス確認中: ${suiPath}` })
       try {
         await fs.access(suiPath)
         const version = await this.getSuiVersion(suiPath)
         this.suiPath = suiPath
+        this.emit('log', { level: 'info', message: `SUI検出成功 - パス: ${suiPath}, バージョン: ${version}` })
         return {
           installed: true,
           version,
           path: suiPath,
         }
       } catch (error) {
+        this.emit('log', { level: 'info', message: `パス無効: ${suiPath}` })
         // パスが存在しない場合は次を試す
         continue
       }
     }
+
+    this.emit('log', { level: 'error', message: 'SUIインストールが見つかりません' })
 
     return {
       installed: false,
@@ -104,15 +116,22 @@ export class SuiService extends EventEmitter {
   }
 
   async checkExistingProcesses(): Promise<{ processes: Array<{ pid: number; command: string; port?: string }> }> {
+    this.emit('log', { level: 'info', message: '既存SUIプロセス検索開始' })
+    
     try {
       // Try platform-specific approach first (pgrep for Unix-like systems)
+      this.emit('log', { level: 'info', message: 'pgrep方式でプロセス検索中...' })
       const processes = await this.findProcessesWithPgrep()
       if (processes.length > 0) {
+        this.emit('log', { level: 'info', message: `pgrep方式で${processes.length}個のSUIプロセスを検出` })
         return { processes }
       }
       
       // Fallback to regex-based ps parsing if pgrep fails
-      return await this.findProcessesWithPs()
+      this.emit('log', { level: 'info', message: 'pgrep方式で検出されず、ps方式にフォールバック' })
+      const psResult = await this.findProcessesWithPs()
+      this.emit('log', { level: 'info', message: `ps方式で${psResult.processes.length}個のSUIプロセスを検出` })
+      return psResult
     } catch (error) {
       this.emit('log', { level: 'error', message: `プロセス検出エラー: ${error instanceof Error ? error.message : 'Unknown error'}` })
       return { processes: [] }
@@ -141,7 +160,7 @@ export class SuiService extends EventEmitter {
       
       return allProcesses
     } catch (error) {
-      this.emit('log', { level: 'debug', message: `pgrep方式でのプロセス検出に失敗: ${error instanceof Error ? error.message : 'Unknown error'}` })
+      this.emit('log', { level: 'info', message: `pgrep方式でのプロセス検出に失敗: ${error instanceof Error ? error.message : 'Unknown error'}` })
       return []
     }
   }
@@ -258,6 +277,8 @@ export class SuiService extends EventEmitter {
   }
 
   async getProcessStatus(pid: number): Promise<{ running: boolean; details?: any }> {
+    this.emit('log', { level: 'info', message: `PID ${pid}の状態を確認中...` })
+    
     try {
       const { spawn } = await import('child_process')
       
@@ -271,28 +292,33 @@ export class SuiService extends EventEmitter {
         
         psProcess.on('close', (code) => {
           if (code === 0 && output.trim()) {
+            this.emit('log', { level: 'info', message: `PID ${pid}: プロセス実行中` })
             try {
               const result = this.parseProcessOutput(output)
               if (result) {
+                this.emit('log', { level: 'info', message: `PID ${pid}: 詳細情報解析完了 (状態: ${result.state})` })
                 resolve({ running: true, details: result })
               } else {
+                this.emit('log', { level: 'warn', message: `PID ${pid}: 詳細情報解析失敗` })
                 resolve({ running: false })
               }
             } catch (parseError) {
-              this.emit('log', { level: 'error', message: `プロセス出力解析エラー: ${parseError instanceof Error ? parseError.message : 'Unknown error'}` })
+              this.emit('log', { level: 'error', message: `PID ${pid} プロセス出力解析エラー: ${parseError instanceof Error ? parseError.message : 'Unknown error'}` })
               resolve({ running: false })
             }
           } else {
+            this.emit('log', { level: 'info', message: `PID ${pid}: プロセス停止中` })
             resolve({ running: false })
           }
         })
         
-        psProcess.on('error', () => {
+        psProcess.on('error', (error) => {
+          this.emit('log', { level: 'error', message: `PID ${pid} psコマンドエラー: ${error.message}` })
           resolve({ running: false })
         })
       })
     } catch (error) {
-      this.emit('log', { level: 'error', message: `プロセス状態取得エラー: ${error instanceof Error ? error.message : 'Unknown error'}` })
+      this.emit('log', { level: 'error', message: `PID ${pid} プロセス状態取得エラー: ${error instanceof Error ? error.message : 'Unknown error'}` })
       return { running: false }
     }
   }
@@ -387,14 +413,20 @@ export class SuiService extends EventEmitter {
   }
 
   async detectExistingNetwork(autoSync: boolean = false): Promise<{ found: boolean; processes: Array<{ pid: number; command: string; port?: string; status?: any }> }> {
+    this.emit('log', { level: 'info', message: `既存ネットワーク検出開始 (autoSync: ${autoSync})` })
+    
     const { processes } = await this.checkExistingProcesses()
     
     if (processes.length === 0) {
+      this.emit('log', { level: 'info', message: '既存SUIプロセスは見つかりませんでした' })
       return { found: false, processes: [] }
     }
 
+    this.emit('log', { level: 'info', message: `${processes.length}個のSUIプロセスを検出、詳細情報を取得中...` })
+    
     const processesWithStatus = await Promise.all(
       processes.map(async (process) => {
+        this.emit('log', { level: 'info', message: `PID ${process.pid}の詳細情報を取得中...` })
         const status = await this.getProcessStatus(process.pid)
         return { ...process, status: status.details }
       })
@@ -404,7 +436,10 @@ export class SuiService extends EventEmitter {
     
     // 既存プロセスが見つかった場合、autoSyncがtrueの時のみネットワーク状態を更新
     if (processesWithStatus.length > 0 && autoSync) {
+      this.emit('log', { level: 'info', message: '自動同期を実行中...' })
       await this.syncWithExistingNetwork(processesWithStatus)
+    } else if (processesWithStatus.length > 0) {
+      this.emit('log', { level: 'info', message: '既存プロセス検出済み（自動同期は無効）' })
     }
     
     return { found: true, processes: processesWithStatus }
@@ -488,10 +523,14 @@ export class SuiService extends EventEmitter {
     }
   }
 
-  async updateNetworkStatus(port: string = '9000'): Promise<void> {
+  public async updateNetworkStatus(port: string = '9000'): Promise<void> {
     try {
+      this.emit('log', { level: 'info', message: `updateNetworkStatus呼び出し (ポート:${port})` })
+      
       // RPC経由でネットワーク情報を取得
       const networkInfo = await this.getNetworkInfo(port)
+      
+      this.emit('log', { level: 'info', message: `getNetworkInfo結果: ${JSON.stringify(networkInfo)}` })
       
       if (networkInfo.success) {
         // 現在の状態を更新
@@ -503,9 +542,13 @@ export class SuiService extends EventEmitter {
           pid: this.suiProcess?.pid || this.currentStatus.pid,
         }
         
+        this.emit('log', { level: 'info', message: `更新後のcurrentStatus: ${JSON.stringify(this.currentStatus)}` })
+        
         // 状態変更を通知
         this.emit('status-change', this.currentStatus)
         this.emit('log', { level: 'info', message: 'ネットワーク状態を更新しました' })
+      } else {
+        this.emit('log', { level: 'warn', message: 'ネットワーク情報の取得に失敗しました' })
       }
     } catch (error) {
       this.emit('log', { level: 'warn', message: `ネットワーク状態更新エラー: ${error instanceof Error ? error.message : 'Unknown error'}` })
@@ -521,7 +564,7 @@ export class SuiService extends EventEmitter {
         const curlProcess = spawn('curl', [
           '-X', 'POST',
           '-H', 'Content-Type: application/json',
-          '-d', '{"jsonrpc":"2.0","method":"sui_getLatestSuiSystemState","params":[],"id":1}',
+          '-d', '{"jsonrpc":"2.0","method":"suix_getLatestSuiSystemState","params":[],"id":1}',
           `http://localhost:${port}`,
           '--connect-timeout', '3',
           '--max-time', '10',
@@ -534,10 +577,12 @@ export class SuiService extends EventEmitter {
           output += data.toString()
         })
         
+        console.log('curlProcess cloase start', output);
         curlProcess.on('close', (code) => {
           if (code === 0 && output.includes('jsonrpc')) {
             try {
               const response = JSON.parse(output)
+              console.log('curlProcess response.result', response.result);
               if (response.result) {
                 // SUIシステム状態から情報を抽出
                 const systemState = response.result
@@ -630,46 +675,57 @@ export class SuiService extends EventEmitter {
   }
 
   async killProcess(pid: number): Promise<{ success: boolean; message: string }> {
+    this.emit('log', { level: 'info', message: `PID ${pid}の停止を開始...` })
+    
     try {
       const { spawn } = await import('child_process')
       
       // プロセスが存在するかチェック
+      this.emit('log', { level: 'info', message: `PID ${pid}の実行状態を確認中...` })
       const processStatus = await this.getProcessStatus(pid)
       if (!processStatus.running) {
+        this.emit('log', { level: 'warn', message: `PID ${pid}は既に停止済みです` })
         return { success: false, message: `プロセス ${pid} は既に停止しています` }
       }
 
+      this.emit('log', { level: 'info', message: `PID ${pid}にSIGTERMシグナルを送信中...` })
+      
       return new Promise((resolve) => {
         // まずSIGTERMで穏やかに停止を試みる
         const killProcess = spawn('kill', ['-TERM', pid.toString()], { stdio: 'pipe' })
         
         killProcess.on('close', (code) => {
+          this.emit('log', { level: 'info', message: `PID ${pid} kill-TERMコマンド終了コード: ${code}` })
+          
           if (code === 0) {
+            this.emit('log', { level: 'info', message: `PID ${pid}停止確認のため2秒待機中...` })
             // 停止確認のため2秒待つ
             setTimeout(async () => {
               const status = await this.getProcessStatus(pid)
               if (!status.running) {
-                this.emit('log', { level: 'info', message: `プロセス ${pid} を正常に停止しました` })
+                this.emit('log', { level: 'info', message: `PID ${pid}を正常に停止しました` })
                 resolve({ success: true, message: `プロセス ${pid} を正常に停止しました` })
               } else {
+                this.emit('log', { level: 'warn', message: `PID ${pid}はSIGTERMで停止できませんでした。強制停止を実行します` })
                 // SIGTERMで停止できない場合はSIGKILLを使用
                 this.forceKillProcess(pid).then(resolve)
               }
             }, 2000)
           } else {
+            this.emit('log', { level: 'error', message: `PID ${pid} kill-TERMコマンドが失敗しました (exit code: ${code})` })
             // killコマンドが失敗した場合
             resolve({ success: false, message: `プロセス ${pid} の停止に失敗しました (exit code: ${code})` })
           }
         })
         
         killProcess.on('error', (error) => {
-          this.emit('log', { level: 'error', message: `プロセス停止エラー: ${error.message}` })
+          this.emit('log', { level: 'error', message: `PID ${pid} killコマンドエラー: ${error.message}` })
           resolve({ success: false, message: `プロセス停止エラー: ${error.message}` })
         })
       })
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-      this.emit('log', { level: 'error', message: `プロセス停止エラー: ${errorMessage}` })
+      this.emit('log', { level: 'error', message: `PID ${pid} プロセス停止エラー: ${errorMessage}` })
       return { success: false, message: `プロセス停止エラー: ${errorMessage}` }
     }
   }
@@ -745,11 +801,15 @@ export class SuiService extends EventEmitter {
     config: { port?: string; nodeCount?: string }, 
     options: { throwOnExistingProcesses?: boolean } = {}
   ): Promise<{ success: boolean; message: string }> {
+    this.emit('log', { level: 'info', message: 'SUIネットワーク起動処理を開始...' })
+    
     if (this.suiProcess) {
+      this.emit('log', { level: 'warn', message: 'SUIプロセスは既に実行中です' })
       return { success: false, message: 'SUI ネットワークは既に実行中です' }
     }
 
     // 既存のSUIプロセスをチェック
+    this.emit('log', { level: 'info', message: '既存SUIプロセスの確認中...' })
     const existing = await this.detectExistingNetwork()
     if (existing.found) {
       const processMessage = `既存のSUIプロセスが検出されました: ${existing.processes.length}個`
@@ -760,17 +820,23 @@ export class SuiService extends EventEmitter {
       } else {
         this.emit('log', { level: 'warn', message: processMessage })
       }
+    } else {
+      this.emit('log', { level: 'info', message: '既存SUIプロセスは検出されませんでした' })
     }
 
+    this.emit('log', { level: 'info', message: '既存SUIプロセスのクリーンアップ中...' })
     await this.killExistingSuiProcesses()
 
     // SUIインストール確認
+    this.emit('log', { level: 'info', message: 'SUIインストール状況を確認中...' })
     const installation = await this.checkInstallation()
     if (!installation.installed) {
+      this.emit('log', { level: 'error', message: 'SUIがインストールされていません' })
       return { success: false, message: 'SUI がインストールされていません。設定画面でSUIパスを確認してください。' }
     }
 
     this.suiPath = installation.path
+    this.emit('log', { level: 'info', message: `SUI実行ファイル確認完了: ${this.suiPath}` })
 
     try {
       // SUI local network を起動
@@ -778,18 +844,21 @@ export class SuiService extends EventEmitter {
       
       if (config.port) {
         args.push('--fullnode-rpc-port', config.port)
+        this.emit('log', { level: 'info', message: `カスタムRPCポート指定: ${config.port}` })
       }
 
-      this.emit('log', { level: 'info', message: `SUIを起動中: ${this.suiPath} ${args.join(' ')}` })
+      this.emit('log', { level: 'info', message: `SUIプロセス起動コマンド: ${this.suiPath} ${args.join(' ')}` })
 
       this.suiProcess = spawn(this.suiPath, args, {
         stdio: 'pipe',
         env: { ...process.env },
       })
 
+      this.emit('log', { level: 'info', message: `SUIプロセス起動完了 (PID: ${this.suiProcess.pid})` })
       this.setupProcessHandlers()
 
       // プロセス起動の確認を待つ
+      this.emit('log', { level: 'info', message: 'ネットワーク起動完了を待機中...' })
       await this.waitForNetworkStart(config)
 
       this.currentStatus = {
@@ -800,6 +869,7 @@ export class SuiService extends EventEmitter {
         pid: this.suiProcess.pid,
       }
 
+      this.emit('log', { level: 'info', message: `SUIネットワーク起動完了 (PID: ${this.suiProcess.pid}, ノード数: ${this.currentStatus.nodeCount})` })
       this.emit('status-change', this.currentStatus)
       return { success: true, message: 'SUI ネットワークが正常に起動しました' }
 
@@ -836,10 +906,16 @@ export class SuiService extends EventEmitter {
   }
 
   async stopNetwork(): Promise<{ success: boolean; message: string }> {
+    this.emit('log', { level: 'info', message: 'SUIネットワーク停止処理を開始...' })
+    
     if (!this.suiProcess) {
+      this.emit('log', { level: 'warn', message: 'SUIプロセスは実行されていません' })
       return { success: false, message: 'SUI ネットワークは実行されていません' }
     }
 
+    const processId = this.suiProcess.pid
+    this.emit('log', { level: 'info', message: `PID ${processId}にSIGTERMシグナルを送信中...` })
+    
     try {
       // プロセスを安全に終了
       this.suiProcess.kill('SIGTERM')
@@ -847,10 +923,15 @@ export class SuiService extends EventEmitter {
       // プロセス終了を待つ
       await new Promise<void>((resolve) => {
         if (this.suiProcess) {
-          this.suiProcess.on('exit', () => resolve())
+          this.suiProcess.on('exit', (code, signal) => {
+            this.emit('log', { level: 'info', message: `SUIプロセス正常終了 (PID: ${processId}, code: ${code}, signal: ${signal})` })
+            resolve()
+          })
+          
           // タイムアウト後は強制終了
           setTimeout(() => {
             if (this.suiProcess && !this.suiProcess.killed) {
+              this.emit('log', { level: 'warn', message: `PID ${processId}のタイムアウト、強制終了実行中...` })
               this.suiProcess.kill('SIGKILL')
             }
             resolve()
@@ -869,13 +950,16 @@ export class SuiService extends EventEmitter {
       }
 
       // 状態更新を停止
+      this.emit('log', { level: 'info', message: '定期状態更新を停止中...' })
       this.stopStatusUpdates()
 
+      this.emit('log', { level: 'info', message: 'SUIネットワーク停止完了' })
       this.emit('status-change', this.currentStatus)
       return { success: true, message: 'SUI ネットワークが正常に停止しました' }
 
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      this.emit('log', { level: 'error', message: `SUI停止エラー: ${errorMessage}` })
       return { success: false, message: `SUI ネットワークの停止に失敗しました: ${errorMessage}` }
     }
   }
@@ -935,11 +1019,14 @@ export class SuiService extends EventEmitter {
   }
 
   private async checkNetworkStatus(): Promise<{ ready: boolean; error?: string }> {
+    this.emit('log', { level: 'info', message: 'SUIクライアント接続確認開始' })
+    
     try {
       const { spawn } = await import('child_process')
       
       return new Promise((resolve) => {
         // sui client active-address コマンドでネットワークの状態を確認
+        this.emit('log', { level: 'info', message: `SUIクライアントコマンド実行: ${this.suiPath} client active-address` })
         const checkProcess = spawn(this.suiPath, ['client', 'active-address'], { 
           stdio: 'pipe',
           timeout: 5000 // 5秒でタイムアウト
@@ -958,41 +1045,47 @@ export class SuiService extends EventEmitter {
         
         checkProcess.on('close', (code) => {
           if (code === 0) {
-            // 成功 - ネットワークが利用可能
+            this.emit('log', { level: 'info', message: 'SUIクライアント接続成功' })
             resolve({ ready: true })
           } else {
-            // エラー - ネットワークがまだ利用できない
+            this.emit('log', { level: 'info', message: `SUIクライアント接続失敗 (code: ${code}, error: ${errorOutput})` })
             resolve({ ready: false, error: errorOutput })
           }
         })
         
         checkProcess.on('error', (error) => {
+          this.emit('log', { level: 'info', message: `SUIクライアントコマンドエラー: ${error.message}` })
           resolve({ ready: false, error: error.message })
         })
         
         // タイムアウト処理
         setTimeout(() => {
           if (!checkProcess.killed) {
+            this.emit('log', { level: 'info', message: 'SUIクライアントコマンドタイムアウト' })
             checkProcess.kill()
             resolve({ ready: false, error: 'Command timeout' })
           }
         }, 5000)
       })
     } catch (error) {
+      this.emit('log', { level: 'error', message: `SUIクライアント確認エラー: ${error instanceof Error ? error.message : 'Unknown error'}` })
       return { ready: false, error: error instanceof Error ? error.message : 'Unknown error' }
     }
   }
 
   private async checkRPCEndpoint(port: string = '9000'): Promise<{ ready: boolean; error?: string }> {
+    this.emit('log', { level: 'info', message: `RPC接続確認開始 (ポート: ${port})` })
+    
     try {
       const { spawn } = await import('child_process')
       
       return new Promise((resolve) => {
         // curlでRPCエンドポイントの確認
+        this.emit('log', { level: 'info', message: `curlコマンドでRPC接続テスト中...` })
         const checkProcess = spawn('curl', [
           '-X', 'POST',
           '-H', 'Content-Type: application/json',
-          '-d', '{"jsonrpc":"2.0","method":"sui_getLatestSuiSystemState","params":[],"id":1}',
+          '-d', '{"jsonrpc":"2.0","method":"suix_getLatestSuiSystemState","params":[],"id":1}',
           `http://localhost:${port}`,
           '--connect-timeout', '3',
           '--max-time', '5',
@@ -1012,18 +1105,21 @@ export class SuiService extends EventEmitter {
         
         checkProcess.on('close', (code) => {
           if (code === 0 && output.includes('jsonrpc')) {
-            // RPCエンドポイントが応答している
+            this.emit('log', { level: 'info', message: `RPC接続成功 (ポート: ${port})` })
             resolve({ ready: true })
           } else {
+            this.emit('log', { level: 'info', message: `RPC接続失敗 (ポート: ${port}, code: ${code}, error: ${errorOutput})` })
             resolve({ ready: false, error: errorOutput || 'No valid RPC response' })
           }
         })
         
         checkProcess.on('error', (error) => {
+          this.emit('log', { level: 'info', message: `RPC接続curlエラー: ${error.message}` })
           resolve({ ready: false, error: error.message })
         })
       })
     } catch (error) {
+      this.emit('log', { level: 'error', message: `RPC接続確認エラー: ${error instanceof Error ? error.message : 'Unknown error'}` })
       return { ready: false, error: error instanceof Error ? error.message : 'Unknown error' }
     }
   }
@@ -1181,7 +1277,7 @@ export class SuiService extends EventEmitter {
         // RPCは応答するがクライアントコマンドが失敗する場合
         this.emit('log', { level: 'info', message: 'RPC接続確認済み、クライアント設定を確認中...' })
       } else {
-        this.emit('log', { level: 'debug', message: `RPC確認失敗: ${rpcCheck.error}` })
+        this.emit('log', { level: 'info', message: `RPC確認失敗: ${rpcCheck.error}` })
       }
       
       // 3秒後に再試行（無限ループ、実際のネットワーク状態で判断）

--- a/src/main/services/SuiService.ts
+++ b/src/main/services/SuiService.ts
@@ -159,22 +159,15 @@ export class SuiService extends EventEmitter {
         
         psProcess.on('close', (code) => {
           if (code === 0 && output.trim()) {
-            const lines = output.split('\n')
-            if (lines.length > 1) {
-              const processInfo = lines[1].trim().split(/\s+/)
-              resolve({
-                running: true,
-                details: {
-                  pid: parseInt(processInfo[0]),
-                  ppid: parseInt(processInfo[1]),
-                  state: processInfo[2],
-                  cpu: parseFloat(processInfo[3]),
-                  memory: parseFloat(processInfo[4]),
-                  time: processInfo[5],
-                  command: processInfo.slice(6).join(' ')
-                }
-              })
-            } else {
+            try {
+              const result = this.parseProcessOutput(output)
+              if (result) {
+                resolve({ running: true, details: result })
+              } else {
+                resolve({ running: false })
+              }
+            } catch (parseError) {
+              this.emit('log', { level: 'error', message: `プロセス出力解析エラー: ${parseError instanceof Error ? parseError.message : 'Unknown error'}` })
               resolve({ running: false })
             }
           } else {
@@ -190,6 +183,95 @@ export class SuiService extends EventEmitter {
       this.emit('log', { level: 'error', message: `プロセス状態取得エラー: ${error instanceof Error ? error.message : 'Unknown error'}` })
       return { running: false }
     }
+  }
+
+  private parseProcessOutput(output: string): any | null {
+    const lines = output.split('\n').filter(line => line.trim())
+    
+    if (lines.length < 2) {
+      return null
+    }
+
+    const headerLine = lines[0].trim()
+    const dataLine = lines[1].trim()
+
+    // Parse header to get column positions and names
+    const columns = this.parseHeaderColumns(headerLine)
+    
+    if (columns.length === 0) {
+      throw new Error('Unable to parse ps header columns')
+    }
+
+    // Parse data line using column positions
+    const values = this.parseDataLine(dataLine, columns)
+    
+    // Map values to expected structure
+    return {
+      pid: this.parseIntValue(values.PID),
+      ppid: this.parseIntValue(values.PPID),
+      state: values.STAT || values.STATE || 'Unknown',
+      cpu: this.parseFloatValue(values['%CPU'] || values.PCPU),
+      memory: this.parseFloatValue(values['%MEM'] || values.PMEM),
+      time: values.TIME || 'Unknown',
+      command: values.COMMAND || values.CMD || 'Unknown'
+    }
+  }
+
+  private parseHeaderColumns(headerLine: string): Array<{ name: string; start: number; end: number }> {
+    const columns: Array<{ name: string; start: number; end: number }> = []
+    const headerParts = headerLine.split(/\s+/)
+    let currentPos = 0
+
+    for (let i = 0; i < headerParts.length; i++) {
+      const columnName = headerParts[i]
+      const start = headerLine.indexOf(columnName, currentPos)
+      
+      // For all columns except the last one, find the end by looking for the next column
+      let end: number
+      if (i < headerParts.length - 1) {
+        const nextColumn = headerParts[i + 1]
+        const nextStart = headerLine.indexOf(nextColumn, start + columnName.length)
+        end = nextStart
+      } else {
+        // Last column extends to the end
+        end = -1
+      }
+
+      columns.push({ name: columnName, start, end })
+      currentPos = start + columnName.length
+    }
+
+    return columns
+  }
+
+  private parseDataLine(dataLine: string, columns: Array<{ name: string; start: number; end: number }>): Record<string, string> {
+    const values: Record<string, string> = {}
+
+    for (const column of columns) {
+      let value: string
+      if (column.end === -1) {
+        // Last column - take everything from start to end
+        value = dataLine.substring(column.start).trim()
+      } else {
+        // Extract value using start and end positions
+        value = dataLine.substring(column.start, column.end).trim()
+      }
+      values[column.name] = value
+    }
+
+    return values
+  }
+
+  private parseIntValue(value: string | undefined): number {
+    if (!value || value === 'Unknown') return 0
+    const parsed = parseInt(value)
+    return isNaN(parsed) ? 0 : parsed
+  }
+
+  private parseFloatValue(value: string | undefined): number {
+    if (!value || value === 'Unknown') return 0.0
+    const parsed = parseFloat(value)
+    return isNaN(parsed) ? 0.0 : parsed
   }
 
   async detectExistingNetwork(autoSync: boolean = false): Promise<{ found: boolean; processes: Array<{ pid: number; command: string; port?: string; status?: any }> }> {

--- a/src/main/services/SuiService.ts
+++ b/src/main/services/SuiService.ts
@@ -192,7 +192,7 @@ export class SuiService extends EventEmitter {
     }
   }
 
-  async detectExistingNetwork(): Promise<{ found: boolean; processes: Array<{ pid: number; command: string; port?: string; status?: any }> }> {
+  async detectExistingNetwork(autoSync: boolean = false): Promise<{ found: boolean; processes: Array<{ pid: number; command: string; port?: string; status?: any }> }> {
     const { processes } = await this.checkExistingProcesses()
     
     if (processes.length === 0) {
@@ -208,8 +208,8 @@ export class SuiService extends EventEmitter {
 
     this.emit('log', { level: 'info', message: `検出されたSUIプロセス: ${processes.length}個` })
     
-    // 既存プロセスが見つかった場合、ネットワーク状態を更新
-    if (processesWithStatus.length > 0) {
+    // 既存プロセスが見つかった場合、autoSyncがtrueの時のみネットワーク状態を更新
+    if (processesWithStatus.length > 0 && autoSync) {
       await this.syncWithExistingNetwork(processesWithStatus)
     }
     

--- a/src/main/services/SuiService.ts
+++ b/src/main/services/SuiService.ts
@@ -20,6 +20,7 @@ export interface SuiInstallation {
 export class SuiService extends EventEmitter {
   private suiProcess: ChildProcess | null = null
   private suiPath: string = ''
+  private statusUpdateInterval: NodeJS.Timeout | null = null
   private currentStatus: SuiStatus = {
     running: false,
     nodeCount: 0,
@@ -102,12 +103,461 @@ export class SuiService extends EventEmitter {
     })
   }
 
+  async checkExistingProcesses(): Promise<{ processes: Array<{ pid: number; command: string; port?: string }> }> {
+    try {
+      const { spawn } = await import('child_process')
+      
+      return new Promise((resolve) => {
+        const psProcess = spawn('ps', ['aux'], { stdio: 'pipe' })
+        let output = ''
+        
+        psProcess.stdout?.on('data', (data) => {
+          output += data.toString()
+        })
+        
+        psProcess.on('close', () => {
+          const lines = output.split('\n')
+          const suiProcesses = lines
+            .filter(line => line.includes('sui start') || line.includes('sui-test-validator'))
+            .map(line => {
+              const parts = line.trim().split(/\s+/)
+              const pid = parseInt(parts[1])
+              const command = parts.slice(10).join(' ')
+              
+              // ポート番号を抽出
+              const portMatch = command.match(/--fullnode-rpc-port\s+(\d+)|--port\s+(\d+)/)
+              const port = portMatch ? (portMatch[1] || portMatch[2]) : undefined
+              
+              return { pid, command, port }
+            })
+            .filter(process => !isNaN(process.pid))
+          
+          resolve({ processes: suiProcesses })
+        })
+        
+        psProcess.on('error', () => {
+          resolve({ processes: [] })
+        })
+      })
+    } catch (error) {
+      this.emit('log', { level: 'error', message: `プロセス検出エラー: ${error instanceof Error ? error.message : 'Unknown error'}` })
+      return { processes: [] }
+    }
+  }
+
+  async getProcessStatus(pid: number): Promise<{ running: boolean; details?: any }> {
+    try {
+      const { spawn } = await import('child_process')
+      
+      return new Promise((resolve) => {
+        const psProcess = spawn('ps', ['-p', pid.toString(), '-o', 'pid,ppid,state,pcpu,pmem,time,command'], { stdio: 'pipe' })
+        let output = ''
+        
+        psProcess.stdout?.on('data', (data) => {
+          output += data.toString()
+        })
+        
+        psProcess.on('close', (code) => {
+          if (code === 0 && output.trim()) {
+            const lines = output.split('\n')
+            if (lines.length > 1) {
+              const processInfo = lines[1].trim().split(/\s+/)
+              resolve({
+                running: true,
+                details: {
+                  pid: parseInt(processInfo[0]),
+                  ppid: parseInt(processInfo[1]),
+                  state: processInfo[2],
+                  cpu: parseFloat(processInfo[3]),
+                  memory: parseFloat(processInfo[4]),
+                  time: processInfo[5],
+                  command: processInfo.slice(6).join(' ')
+                }
+              })
+            } else {
+              resolve({ running: false })
+            }
+          } else {
+            resolve({ running: false })
+          }
+        })
+        
+        psProcess.on('error', () => {
+          resolve({ running: false })
+        })
+      })
+    } catch (error) {
+      this.emit('log', { level: 'error', message: `プロセス状態取得エラー: ${error instanceof Error ? error.message : 'Unknown error'}` })
+      return { running: false }
+    }
+  }
+
+  async detectExistingNetwork(): Promise<{ found: boolean; processes: Array<{ pid: number; command: string; port?: string; status?: any }> }> {
+    const { processes } = await this.checkExistingProcesses()
+    
+    if (processes.length === 0) {
+      return { found: false, processes: [] }
+    }
+
+    const processesWithStatus = await Promise.all(
+      processes.map(async (process) => {
+        const status = await this.getProcessStatus(process.pid)
+        return { ...process, status: status.details }
+      })
+    )
+
+    this.emit('log', { level: 'info', message: `検出されたSUIプロセス: ${processes.length}個` })
+    
+    // 既存プロセスが見つかった場合、ネットワーク状態を更新
+    if (processesWithStatus.length > 0) {
+      await this.syncWithExistingNetwork(processesWithStatus)
+    }
+    
+    return { found: true, processes: processesWithStatus }
+  }
+
+  async syncWithExistingNetworkManually(): Promise<{ success: boolean; message: string }> {
+    try {
+      this.emit('log', { level: 'info', message: '既存ネットワークとの手動同期を開始...' })
+      
+      const { processes } = await this.detectExistingNetwork()
+      
+      if (processes.length === 0) {
+        return { success: false, message: '既存のSUIプロセスが見つかりません' }
+      }
+      
+      const activeProcess = processes.find(p => p.status?.state === 'R') || processes[0]
+      const port = activeProcess?.port || '9000'
+      
+      // ネットワーク接続確認
+      const rpcCheck = await this.checkRPCEndpoint(port)
+      if (rpcCheck.ready) {
+        // 状態を更新
+        await this.updateNetworkStatus(port)
+        
+        // 既存プロセスの情報を設定
+        this.currentStatus = {
+          ...this.currentStatus,
+          running: true,
+          pid: activeProcess.pid,
+        }
+        
+        // 定期更新を開始
+        this.startStatusUpdates(port)
+        
+        // 状態変更を通知
+        this.emit('status-change', this.currentStatus)
+        
+        return { success: true, message: `既存ネットワーク(PID:${activeProcess.pid}, ポート:${port})との同期が完了しました` }
+      } else {
+        return { success: false, message: `既存プロセスが見つかりましたが、ネットワーク接続に失敗しました (ポート:${port})` }
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      this.emit('log', { level: 'error', message: `手動同期エラー: ${errorMessage}` })
+      return { success: false, message: `手動同期エラー: ${errorMessage}` }
+    }
+  }
+
+  private async syncWithExistingNetwork(processes: Array<{ pid: number; command: string; port?: string; status?: any }>): Promise<void> {
+    try {
+      // 最初に見つかったプロセスからポート情報を取得
+      const activeProcess = processes.find(p => p.status?.state === 'R') || processes[0]
+      const port = activeProcess?.port || '9000'
+      
+      this.emit('log', { level: 'info', message: `既存ネットワーク(ポート:${port})との同期を開始...` })
+      
+      // ネットワーク接続確認
+      const rpcCheck = await this.checkRPCEndpoint(port)
+      if (rpcCheck.ready) {
+        // 状態を更新
+        await this.updateNetworkStatus(port)
+        
+        // 既存プロセスの情報を設定
+        this.currentStatus = {
+          ...this.currentStatus,
+          running: true,
+          pid: activeProcess.pid,
+        }
+        
+        // 定期更新を開始
+        this.startStatusUpdates(port)
+        
+        // 状態変更を通知
+        this.emit('status-change', this.currentStatus)
+        this.emit('log', { level: 'info', message: '既存ネットワークとの同期が完了しました' })
+      } else {
+        this.emit('log', { level: 'warn', message: `既存プロセスが見つかりましたが、ネットワーク接続に失敗しました (ポート:${port})` })
+      }
+    } catch (error) {
+      this.emit('log', { level: 'error', message: `既存ネットワーク同期エラー: ${error instanceof Error ? error.message : 'Unknown error'}` })
+    }
+  }
+
+  async updateNetworkStatus(port: string = '9000'): Promise<void> {
+    try {
+      // RPC経由でネットワーク情報を取得
+      const networkInfo = await this.getNetworkInfo(port)
+      
+      if (networkInfo.success) {
+        // 現在の状態を更新
+        this.currentStatus = {
+          running: true,
+          nodeCount: networkInfo.data.nodeCount || this.currentStatus.nodeCount,
+          blockHeight: networkInfo.data.blockHeight || this.currentStatus.blockHeight,
+          transactions: networkInfo.data.transactions || this.currentStatus.transactions,
+          pid: this.suiProcess?.pid || this.currentStatus.pid,
+        }
+        
+        // 状態変更を通知
+        this.emit('status-change', this.currentStatus)
+        this.emit('log', { level: 'info', message: 'ネットワーク状態を更新しました' })
+      }
+    } catch (error) {
+      this.emit('log', { level: 'warn', message: `ネットワーク状態更新エラー: ${error instanceof Error ? error.message : 'Unknown error'}` })
+    }
+  }
+
+  private async getNetworkInfo(port: string = '9000'): Promise<{ success: boolean; data?: any }> {
+    try {
+      const { spawn } = await import('child_process')
+      
+      return new Promise((resolve) => {
+        // SUIのRPCを使用してネットワーク情報を取得
+        const curlProcess = spawn('curl', [
+          '-X', 'POST',
+          '-H', 'Content-Type: application/json',
+          '-d', '{"jsonrpc":"2.0","method":"sui_getLatestSuiSystemState","params":[],"id":1}',
+          `http://localhost:${port}`,
+          '--connect-timeout', '3',
+          '--max-time', '10',
+          '--silent'
+        ], { stdio: 'pipe' })
+        
+        let output = ''
+        
+        curlProcess.stdout?.on('data', (data) => {
+          output += data.toString()
+        })
+        
+        curlProcess.on('close', (code) => {
+          if (code === 0 && output.includes('jsonrpc')) {
+            try {
+              const response = JSON.parse(output)
+              if (response.result) {
+                // SUIシステム状態から情報を抽出
+                const systemState = response.result
+                resolve({
+                  success: true,
+                  data: {
+                    nodeCount: systemState.activeValidators?.length || 4,
+                    blockHeight: parseInt(systemState.epoch) || 0,
+                    transactions: systemState.epochStartTimestampMs ? Math.floor(Date.now() / 1000) - Math.floor(systemState.epochStartTimestampMs / 1000) : 0,
+                  }
+                })
+              } else {
+                resolve({ success: false })
+              }
+            } catch (error) {
+              resolve({ success: false })
+            }
+          } else {
+            resolve({ success: false })
+          }
+        })
+        
+        curlProcess.on('error', () => {
+          resolve({ success: false })
+        })
+      })
+    } catch (error) {
+      return { success: false }
+    }
+  }
+
+  async verifyNetworkConnection(port: string = '9000'): Promise<{ 
+    connected: boolean; 
+    rpcReady: boolean; 
+    clientReady: boolean; 
+    message: string; 
+    details?: any 
+  }> {
+    try {
+      this.emit('log', { level: 'info', message: 'ネットワーク接続を確認しています...' })
+      
+      // 1. RPC endpoint の確認
+      const rpcCheck = await this.checkRPCEndpoint(port)
+      this.emit('log', { 
+        level: rpcCheck.ready ? 'info' : 'warn', 
+        message: rpcCheck.ready ? 'RPC接続: 成功' : `RPC接続: 失敗 (${rpcCheck.error})` 
+      })
+      
+      // 2. SUI client コマンドでの確認
+      const clientCheck = await this.checkNetworkStatus()
+      this.emit('log', { 
+        level: clientCheck.ready ? 'info' : 'warn', 
+        message: clientCheck.ready ? 'SUIクライアント: 成功' : `SUIクライアント: 失敗 (${clientCheck.error})` 
+      })
+      
+      const connected = rpcCheck.ready && clientCheck.ready
+      let message = ''
+      
+      if (connected) {
+        message = 'ネットワーク接続が正常に確認されました'
+        // 接続が確認された場合、状態を更新
+        await this.updateNetworkStatus(port)
+      } else if (rpcCheck.ready) {
+        message = 'RPC接続は確認されましたが、SUIクライアントの設定に問題があります'
+      } else {
+        message = 'ネットワーク接続に失敗しました'
+      }
+      
+      return {
+        connected,
+        rpcReady: rpcCheck.ready,
+        clientReady: clientCheck.ready,
+        message,
+        details: {
+          rpcError: rpcCheck.error,
+          clientError: clientCheck.error,
+          port
+        }
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      this.emit('log', { level: 'error', message: `ネットワーク確認エラー: ${errorMessage}` })
+      return {
+        connected: false,
+        rpcReady: false,
+        clientReady: false,
+        message: `ネットワーク確認エラー: ${errorMessage}`
+      }
+    }
+  }
+
+  async killProcess(pid: number): Promise<{ success: boolean; message: string }> {
+    try {
+      const { spawn } = await import('child_process')
+      
+      // プロセスが存在するかチェック
+      const processStatus = await this.getProcessStatus(pid)
+      if (!processStatus.running) {
+        return { success: false, message: `プロセス ${pid} は既に停止しています` }
+      }
+
+      return new Promise((resolve) => {
+        // まずSIGTERMで穏やかに停止を試みる
+        const killProcess = spawn('kill', ['-TERM', pid.toString()], { stdio: 'pipe' })
+        
+        killProcess.on('close', (code) => {
+          if (code === 0) {
+            // 停止確認のため2秒待つ
+            setTimeout(async () => {
+              const status = await this.getProcessStatus(pid)
+              if (!status.running) {
+                this.emit('log', { level: 'info', message: `プロセス ${pid} を正常に停止しました` })
+                resolve({ success: true, message: `プロセス ${pid} を正常に停止しました` })
+              } else {
+                // SIGTERMで停止できない場合はSIGKILLを使用
+                this.forceKillProcess(pid).then(resolve)
+              }
+            }, 2000)
+          } else {
+            // killコマンドが失敗した場合
+            resolve({ success: false, message: `プロセス ${pid} の停止に失敗しました (exit code: ${code})` })
+          }
+        })
+        
+        killProcess.on('error', (error) => {
+          this.emit('log', { level: 'error', message: `プロセス停止エラー: ${error.message}` })
+          resolve({ success: false, message: `プロセス停止エラー: ${error.message}` })
+        })
+      })
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      this.emit('log', { level: 'error', message: `プロセス停止エラー: ${errorMessage}` })
+      return { success: false, message: `プロセス停止エラー: ${errorMessage}` }
+    }
+  }
+
+  private async forceKillProcess(pid: number): Promise<{ success: boolean; message: string }> {
+    try {
+      const { spawn } = await import('child_process')
+      
+      return new Promise((resolve) => {
+        const killProcess = spawn('kill', ['-KILL', pid.toString()], { stdio: 'pipe' })
+        
+        killProcess.on('close', (code) => {
+          if (code === 0) {
+            this.emit('log', { level: 'warn', message: `プロセス ${pid} を強制停止しました` })
+            resolve({ success: true, message: `プロセス ${pid} を強制停止しました` })
+          } else {
+            resolve({ success: false, message: `プロセス ${pid} の強制停止に失敗しました` })
+          }
+        })
+        
+        killProcess.on('error', (error) => {
+          resolve({ success: false, message: `強制停止エラー: ${error.message}` })
+        })
+      })
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      return { success: false, message: `強制停止エラー: ${errorMessage}` }
+    }
+  }
+
+  async killAllExistingProcesses(): Promise<{ success: boolean; message: string; results: Array<{ pid: number; success: boolean; message: string }> }> {
+    try {
+      const { processes } = await this.checkExistingProcesses()
+      
+      if (processes.length === 0) {
+        return { success: true, message: '停止対象のプロセスはありません', results: [] }
+      }
+
+      const results = await Promise.all(
+        processes.map(async (process) => {
+          const result = await this.killProcess(process.pid)
+          return {
+            pid: process.pid,
+            success: result.success,
+            message: result.message
+          }
+        })
+      )
+
+      const successCount = results.filter(r => r.success).length
+      const failureCount = results.length - successCount
+
+      let message = `${successCount}個のプロセスを停止しました`
+      if (failureCount > 0) {
+        message += `（${failureCount}個のプロセスの停止に失敗）`
+      }
+
+      this.emit('log', { level: 'info', message })
+
+      return {
+        success: failureCount === 0,
+        message,
+        results
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      this.emit('log', { level: 'error', message: `一括停止エラー: ${errorMessage}` })
+      return { success: false, message: `一括停止エラー: ${errorMessage}`, results: [] }
+    }
+  }
+
   async startNetwork(config: { port?: string; nodeCount?: string }): Promise<{ success: boolean; message: string }> {
     if (this.suiProcess) {
       return { success: false, message: 'SUI ネットワークは既に実行中です' }
     }
 
     // 既存のSUIプロセスをチェック
+    const existing = await this.detectExistingNetwork()
+    if (existing.found) {
+      this.emit('log', { level: 'warn', message: `既存のSUIプロセスが検出されました: ${existing.processes.length}個` })
+    }
+
     await this.killExistingSuiProcesses()
 
     // SUIインストール確認
@@ -136,7 +586,7 @@ export class SuiService extends EventEmitter {
       this.setupProcessHandlers()
 
       // プロセス起動の確認を待つ
-      await this.waitForNetworkStart()
+      await this.waitForNetworkStart(config)
 
       this.currentStatus = {
         running: true,
@@ -214,6 +664,9 @@ export class SuiService extends EventEmitter {
         transactions: 0,
       }
 
+      // 状態更新を停止
+      this.stopStatusUpdates()
+
       this.emit('status-change', this.currentStatus)
       return { success: true, message: 'SUI ネットワークが正常に停止しました' }
 
@@ -234,6 +687,9 @@ export class SuiService extends EventEmitter {
       this.suiProcess = null
     }
     
+    // 状態更新を停止
+    this.stopStatusUpdates()
+    
     // イベントリスナーをクリア
     this.removeAllListeners()
     
@@ -251,6 +707,121 @@ export class SuiService extends EventEmitter {
 
   setSuiPath(path: string): void {
     this.suiPath = path
+  }
+
+  private startStatusUpdates(port: string = '9000'): void {
+    // 既存のインターバルをクリア
+    if (this.statusUpdateInterval) {
+      clearInterval(this.statusUpdateInterval)
+    }
+    
+    // 10秒間隔で状態更新
+    this.statusUpdateInterval = setInterval(() => {
+      if (this.currentStatus.running) {
+        this.updateNetworkStatus(port)
+      }
+    }, 10000)
+  }
+
+  private stopStatusUpdates(): void {
+    if (this.statusUpdateInterval) {
+      clearInterval(this.statusUpdateInterval)
+      this.statusUpdateInterval = null
+    }
+  }
+
+  private async checkNetworkStatus(): Promise<{ ready: boolean; error?: string }> {
+    try {
+      const { spawn } = await import('child_process')
+      
+      return new Promise((resolve) => {
+        // sui client active-address コマンドでネットワークの状態を確認
+        const checkProcess = spawn(this.suiPath, ['client', 'active-address'], { 
+          stdio: 'pipe',
+          timeout: 5000 // 5秒でタイムアウト
+        })
+        
+        let output = ''
+        let errorOutput = ''
+        
+        checkProcess.stdout?.on('data', (data) => {
+          output += data.toString()
+        })
+        
+        checkProcess.stderr?.on('data', (data) => {
+          errorOutput += data.toString()
+        })
+        
+        checkProcess.on('close', (code) => {
+          if (code === 0) {
+            // 成功 - ネットワークが利用可能
+            resolve({ ready: true })
+          } else {
+            // エラー - ネットワークがまだ利用できない
+            resolve({ ready: false, error: errorOutput })
+          }
+        })
+        
+        checkProcess.on('error', (error) => {
+          resolve({ ready: false, error: error.message })
+        })
+        
+        // タイムアウト処理
+        setTimeout(() => {
+          if (!checkProcess.killed) {
+            checkProcess.kill()
+            resolve({ ready: false, error: 'Command timeout' })
+          }
+        }, 5000)
+      })
+    } catch (error) {
+      return { ready: false, error: error instanceof Error ? error.message : 'Unknown error' }
+    }
+  }
+
+  private async checkRPCEndpoint(port: string = '9000'): Promise<{ ready: boolean; error?: string }> {
+    try {
+      const { spawn } = await import('child_process')
+      
+      return new Promise((resolve) => {
+        // curlでRPCエンドポイントの確認
+        const checkProcess = spawn('curl', [
+          '-X', 'POST',
+          '-H', 'Content-Type: application/json',
+          '-d', '{"jsonrpc":"2.0","method":"sui_getLatestSuiSystemState","params":[],"id":1}',
+          `http://localhost:${port}`,
+          '--connect-timeout', '3',
+          '--max-time', '5',
+          '--silent'
+        ], { stdio: 'pipe' })
+        
+        let output = ''
+        let errorOutput = ''
+        
+        checkProcess.stdout?.on('data', (data) => {
+          output += data.toString()
+        })
+        
+        checkProcess.stderr?.on('data', (data) => {
+          errorOutput += data.toString()
+        })
+        
+        checkProcess.on('close', (code) => {
+          if (code === 0 && output.includes('jsonrpc')) {
+            // RPCエンドポイントが応答している
+            resolve({ ready: true })
+          } else {
+            resolve({ ready: false, error: errorOutput || 'No valid RPC response' })
+          }
+        })
+        
+        checkProcess.on('error', (error) => {
+          resolve({ ready: false, error: error.message })
+        })
+      })
+    } catch (error) {
+      return { ready: false, error: error instanceof Error ? error.message : 'Unknown error' }
+    }
   }
 
   private setupProcessHandlers(): void {
@@ -288,6 +859,10 @@ export class SuiService extends EventEmitter {
         blockHeight: 0,
         transactions: 0,
       }
+      
+      // 状態更新を停止
+      this.stopStatusUpdates()
+      
       this.emit('status-change', this.currentStatus)
     })
 
@@ -296,14 +871,10 @@ export class SuiService extends EventEmitter {
     })
   }
 
-  private async waitForNetworkStart(): Promise<void> {
+  private async waitForNetworkStart(config: { port?: string }): Promise<void> {
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(new Error('ネットワーク起動がタイムアウトしました'))
-      }, 120000) // 120秒でタイムアウト（genesis生成時間を考慮）
-
       let hasStartedGenesisCreation = false
-      let hasSeenNetworkStartup = false
+      let checkingNetwork = false
       
       const onLog = (log: { level: string; message: string }) => {
         const message = log.message.toLowerCase()
@@ -318,8 +889,9 @@ export class SuiService extends EventEmitter {
           this.emit('log', { level: 'info', message: 'Genesis作成を開始しました...' })
         }
         
-        // ネットワーク起動の中間段階を検出
-        if (message.includes('validators generated') ||
+        // ネットワーク起動の兆候を検出したらポーリング開始
+        if (hasStartedGenesisCreation && !checkingNetwork && (
+            message.includes('validators generated') ||
             message.includes('loaded genesis') ||
             message.includes('starting sui node') ||
             message.includes('initializing sui') ||
@@ -331,53 +903,21 @@ export class SuiService extends EventEmitter {
             message.includes('listening on port') ||
             message.includes('server started') ||
             message.includes('fullnode started') ||
-            message.includes('network started')) {
-          hasSeenNetworkStartup = true
-        }
-        
-        // SUIネットワークの起動成功を示すログパターンを探す
-        // より寛容なパターンマッチングを使用
-        if (hasStartedGenesisCreation && (
-            hasSeenNetworkStartup ||
-            message.includes('listening') && message.includes('0.0.0.0') ||
-            message.includes('server') && message.includes('listening') ||
-            message.includes('rpc') && message.includes('listening') ||
-            message.includes('sui') && message.includes('started') ||
-            message.includes('network') && message.includes('running') ||
-            message.includes('fullnode') && message.includes('ready'))) {
+            message.includes('network started'))) {
           
-          // 追加の確認として2秒待つ
-          setTimeout(() => {
-            if (this.suiProcess && this.suiProcess.pid && !this.suiProcess.killed) {
-              clearTimeout(timeout)
-              this.off('log', onLog)
-              this.emit('log', { level: 'info', message: 'SUIネットワークの起動が完了しました' })
-              resolve()
-            }
-          }, 2000)
-          return
+          checkingNetwork = true
+          this.emit('log', { level: 'info', message: 'ネットワーク起動確認を開始しています...' })
+          
+          // ポーリング開始
+          this.startNetworkPolling(config, resolve, reject, onLog)
         }
         
-        // プロセスが10秒以上生きており、genesis作成が始まっていれば成功とみなす
-        // （一部のSUIバージョンでは明確な完了メッセージがない可能性があるため）
-        if (hasStartedGenesisCreation) {
-          setTimeout(() => {
-            if (this.suiProcess && this.suiProcess.pid && !this.suiProcess.killed && this.suiProcess.exitCode === null) {
-              clearTimeout(timeout)
-              this.off('log', onLog)
-              this.emit('log', { level: 'info', message: 'SUIプロセスが安定して実行中です' })
-              resolve()
-            }
-          }, 15000) // 15秒後にプロセスの状態をチェック
-        }
-        
-        // エラーパターンを検出
+        // 早期エラーパターンを検出
         if (message.includes('address already in use') ||
             message.includes('bind') && message.includes('error') ||
             message.includes('panic') ||
             message.includes('failed to start') ||
             message.includes('could not start')) {
-          clearTimeout(timeout)
           this.off('log', onLog)
           reject(new Error('ポートが既に使用されているか、起動エラーが発生しました。他のSUIプロセスを停止してください。'))
         }
@@ -385,15 +925,67 @@ export class SuiService extends EventEmitter {
 
       this.on('log', onLog)
       
-      // 5秒後にプロセスが生きているかチェック
+      // プロセスが早期に終了していないかチェック
       setTimeout(() => {
         if (this.suiProcess && this.suiProcess.exitCode !== null) {
-          clearTimeout(timeout)
           this.off('log', onLog)
           reject(new Error('SUIプロセスが予期せず終了しました'))
         }
       }, 5000)
     })
+  }
+
+  private async startNetworkPolling(
+    config: { port?: string },
+    resolve: () => void,
+    reject: (error: Error) => void,
+    onLog: (log: { level: string; message: string }) => void
+  ): Promise<void> {
+    const port = config.port || '9000'
+    let attempts = 0
+    
+    const poll = async () => {
+      attempts++
+      
+      // プロセスが終了していないかチェック
+      if (!this.suiProcess || this.suiProcess.killed || this.suiProcess.exitCode !== null) {
+        this.off('log', onLog)
+        reject(new Error('SUIプロセスが予期せず終了しました'))
+        return
+      }
+      
+      this.emit('log', { level: 'info', message: `ネットワーク起動確認中... (試行回数: ${attempts})` })
+      
+      // 1. RPC endpoint の確認
+      const rpcCheck = await this.checkRPCEndpoint(port)
+      if (rpcCheck.ready) {
+        // 2. SUI client コマンドでの確認
+        const clientCheck = await this.checkNetworkStatus()
+        if (clientCheck.ready) {
+          this.off('log', onLog)
+          this.emit('log', { level: 'info', message: 'SUIネットワークの起動が確認されました' })
+          
+          // ネットワーク状態を更新
+          this.updateNetworkStatus(port)
+          
+          // 定期的な状態更新を開始
+          this.startStatusUpdates(port)
+          resolve()
+          return
+        }
+        
+        // RPCは応答するがクライアントコマンドが失敗する場合
+        this.emit('log', { level: 'info', message: 'RPC接続確認済み、クライアント設定を確認中...' })
+      } else {
+        this.emit('log', { level: 'debug', message: `RPC確認失敗: ${rpcCheck.error}` })
+      }
+      
+      // 3秒後に再試行（無限ループ、実際のネットワーク状態で判断）
+      setTimeout(poll, 3000)
+    }
+    
+    // 最初のポーリングを2秒後に開始（起動処理の時間を考慮）
+    setTimeout(poll, 2000)
   }
 
   private parseNetworkOutput(output: string): void {

--- a/src/main/services/SuiService.ts
+++ b/src/main/services/SuiService.ts
@@ -741,7 +741,10 @@ export class SuiService extends EventEmitter {
     }
   }
 
-  async startNetwork(config: { port?: string; nodeCount?: string }): Promise<{ success: boolean; message: string }> {
+  async startNetwork(
+    config: { port?: string; nodeCount?: string }, 
+    options: { throwOnExistingProcesses?: boolean } = {}
+  ): Promise<{ success: boolean; message: string }> {
     if (this.suiProcess) {
       return { success: false, message: 'SUI ネットワークは既に実行中です' }
     }
@@ -749,7 +752,14 @@ export class SuiService extends EventEmitter {
     // 既存のSUIプロセスをチェック
     const existing = await this.detectExistingNetwork()
     if (existing.found) {
-      this.emit('log', { level: 'warn', message: `既存のSUIプロセスが検出されました: ${existing.processes.length}個` })
+      const processMessage = `既存のSUIプロセスが検出されました: ${existing.processes.length}個`
+      
+      if (options.throwOnExistingProcesses) {
+        this.emit('log', { level: 'error', message: processMessage })
+        throw new Error(`Port conflict risk: ${processMessage}. Existing processes must be stopped before starting a new network.`)
+      } else {
+        this.emit('log', { level: 'warn', message: processMessage })
+      }
     }
 
     await this.killExistingSuiProcesses()

--- a/src/renderer/src/pages/Dashboard.tsx
+++ b/src/renderer/src/pages/Dashboard.tsx
@@ -24,6 +24,10 @@ import {
   Refresh as RefreshIcon,
   ExpandLess as ExpandLessIcon,
   ExpandMore as ExpandMoreIcon,
+  Delete as DeleteIcon,
+  DeleteSweep as DeleteSweepIcon,
+  NetworkCheck as NetworkCheckIcon,
+  Sync as SyncIcon,
 } from '@mui/icons-material'
 
 interface NetworkStatus {
@@ -40,6 +44,21 @@ interface LogEntry {
   source?: string
 }
 
+interface ExistingProcess {
+  pid: number
+  command: string
+  port?: string
+  status?: {
+    pid: number
+    ppid: number
+    state: string
+    cpu: number
+    memory: number
+    time: string
+    command: string
+  }
+}
+
 const Dashboard: React.FC = () => {
   const [networkStatus, setNetworkStatus] = useState<NetworkStatus>({
     running: false,
@@ -52,6 +71,9 @@ const Dashboard: React.FC = () => {
   const [logs, setLogs] = useState<LogEntry[]>([])
   const [logExpanded, setLogExpanded] = useState(true)
   const [logLevel, setLogLevel] = useState<string>('all')
+  const [existingProcesses, setExistingProcesses] = useState<ExistingProcess[]>([])
+  const [processsExpanded, setProcessExpanded] = useState(false)
+  const [processMonitorInterval, setProcessMonitorInterval] = useState<NodeJS.Timeout | null>(null)
   const logListRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -78,6 +100,12 @@ const Dashboard: React.FC = () => {
 
       // 初期ログロード
       loadInitialLogs()
+      
+      // 既存プロセス検出
+      detectExistingProcesses()
+      
+      // プロセス監視の開始
+      startProcessMonitoring()
     }
 
     // クリーンアップ
@@ -85,6 +113,11 @@ const Dashboard: React.FC = () => {
       if (window.electronAPI) {
         window.electronAPI.sui.removeAllListeners()
         window.electronAPI.logs.removeAllListeners()
+      }
+      
+      // プロセス監視の停止
+      if (processMonitorInterval) {
+        clearInterval(processMonitorInterval)
       }
     }
   }, [])
@@ -108,6 +141,111 @@ const Dashboard: React.FC = () => {
       }
     } catch (error) {
       console.error('Failed to get status:', error)
+    }
+  }
+
+  const detectExistingProcesses = async () => {
+    try {
+      if (window.electronAPI) {
+        const result = await window.electronAPI.sui.detectExistingNetwork()
+        setExistingProcesses(result.processes || [])
+      }
+    } catch (error) {
+      console.error('Failed to detect existing processes:', error)
+    }
+  }
+
+  const startProcessMonitoring = () => {
+    // プロセス監視間隔を5秒に設定
+    const interval = setInterval(() => {
+      if (processsExpanded) {
+        detectExistingProcesses()
+      }
+    }, 5000)
+    
+    setProcessMonitorInterval(interval)
+  }
+
+
+  const handleKillProcess = async (pid: number) => {
+    try {
+      if (window.electronAPI) {
+        const result = await window.electronAPI.sui.killProcess(pid)
+        setMessage(result.message)
+        
+        if (result.success) {
+          // プロセス一覧を更新
+          detectExistingProcesses()
+        }
+      }
+    } catch (error) {
+      setMessage('プロセスの停止に失敗しました')
+    }
+  }
+
+  const handleKillAllProcesses = async () => {
+    setLoading(true)
+    setMessage(null)
+    try {
+      if (window.electronAPI) {
+        const result = await window.electronAPI.sui.killAllProcesses()
+        setMessage(result.message)
+        
+        if (result.success) {
+          // プロセス一覧を更新
+          detectExistingProcesses()
+        }
+      }
+    } catch (error) {
+      setMessage('プロセスの一括停止に失敗しました')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleVerifyConnection = async () => {
+    setLoading(true)
+    setMessage(null)
+    try {
+      if (window.electronAPI) {
+        const profiles = await window.electronAPI.config.getProfiles()
+        const activeProfile = profiles.find(p => p.active)
+        const port = activeProfile?.port || '9000'
+        
+        const result = await window.electronAPI.sui.verifyNetworkConnection(port)
+        setMessage(result.message)
+        
+        // 接続確認後に状態を更新
+        if (result.connected) {
+          await refreshStatus()
+        }
+      }
+    } catch (error) {
+      setMessage('ネットワーク接続確認に失敗しました')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleSyncWithExisting = async () => {
+    setLoading(true)
+    setMessage(null)
+    try {
+      if (window.electronAPI) {
+        const result = await window.electronAPI.sui.syncWithExistingNetwork()
+        setMessage(result.message)
+        
+        // 同期成功後に状態を更新
+        if (result.success) {
+          await refreshStatus()
+          // プロセス一覧も更新
+          detectExistingProcesses()
+        }
+      }
+    } catch (error) {
+      setMessage('既存ネットワークとの同期に失敗しました')
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -217,10 +355,31 @@ const Dashboard: React.FC = () => {
                 <Button
                   variant="outlined"
                   startIcon={<RefreshIcon />}
-                  onClick={refreshStatus}
+                  onClick={() => {
+                    refreshStatus()
+                    detectExistingProcesses()
+                  }}
                   disabled={loading}
                 >
                   状態更新
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="info"
+                  startIcon={<NetworkCheckIcon />}
+                  onClick={handleVerifyConnection}
+                  disabled={loading}
+                >
+                  接続確認
+                </Button>
+                <Button
+                  variant="outlined"
+                  color="warning"
+                  startIcon={<SyncIcon />}
+                  onClick={handleSyncWithExisting}
+                  disabled={loading}
+                >
+                  既存と同期
                 </Button>
               </Box>
             </CardContent>
@@ -276,6 +435,121 @@ const Dashboard: React.FC = () => {
               <Typography variant="h3" color={networkStatus.running ? 'success.main' : 'text.secondary'}>
                 {networkStatus.running ? '正常' : '停止'}
               </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* 既存プロセス状況 */}
+        <Grid item xs={12}>
+          <Card>
+            <CardContent>
+              <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+                <Typography variant="h6">
+                  既存のSUIプロセス
+                </Typography>
+                <Box display="flex" alignItems="center" gap={2}>
+                  <Chip
+                    label={`${existingProcesses.length}個のプロセス`}
+                    color={existingProcesses.length > 0 ? 'warning' : 'default'}
+                  />
+                  {existingProcesses.length > 0 && (
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      color="error"
+                      startIcon={<DeleteSweepIcon />}
+                      onClick={handleKillAllProcesses}
+                      disabled={loading}
+                    >
+                      すべて停止
+                    </Button>
+                  )}
+                  <Button
+                    size="small"
+                    onClick={() => setProcessExpanded(!processsExpanded)}
+                    endIcon={processsExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                  >
+                    {processsExpanded ? '折りたたみ' : '展開'}
+                  </Button>
+                </Box>
+              </Box>
+              
+              {processsExpanded && (
+                <Paper variant="outlined" sx={{ maxHeight: 300, overflow: 'hidden' }}>
+                  <Box sx={{ maxHeight: 300, overflowY: 'auto', backgroundColor: 'background.paper' }}>
+                    <List dense>
+                      {existingProcesses.length > 0 ? (
+                        existingProcesses.map((process, index) => (
+                          <ListItem 
+                            key={index} 
+                            divider={index < existingProcesses.length - 1}
+                            secondaryAction={
+                              <Button
+                                size="small"
+                                variant="outlined"
+                                color="error"
+                                startIcon={<DeleteIcon />}
+                                onClick={() => handleKillProcess(process.pid)}
+                                disabled={loading}
+                              >
+                                停止
+                              </Button>
+                            }
+                          >
+                            <ListItemText
+                              primary={
+                                <Box display="flex" alignItems="center" gap={1} mb={0.5}>
+                                  <Chip
+                                    label={`PID: ${process.pid}`}
+                                    size="small"
+                                    color="primary"
+                                  />
+                                  {process.port && (
+                                    <Chip
+                                      label={`ポート: ${process.port}`}
+                                      size="small"
+                                      color="secondary"
+                                    />
+                                  )}
+                                  {process.status && (
+                                    <Chip
+                                      label={`状態: ${process.status.state}`}
+                                      size="small"
+                                      color={process.status.state === 'R' ? 'success' : 'default'}
+                                    />
+                                  )}
+                                </Box>
+                              }
+                              secondary={
+                                <Box sx={{ pr: 10 }}>
+                                  <Typography
+                                    variant="body2"
+                                    sx={{ fontFamily: 'monospace', fontSize: '0.875rem', wordBreak: 'break-all' }}
+                                  >
+                                    {process.command}
+                                  </Typography>
+                                  {process.status && (
+                                    <Typography variant="caption" color="text.secondary">
+                                      CPU: {process.status.cpu}% | メモリ: {process.status.memory}% | 実行時間: {process.status.time}
+                                    </Typography>
+                                  )}
+                                </Box>
+                              }
+                            />
+                          </ListItem>
+                        ))
+                      ) : (
+                        <ListItem>
+                          <ListItemText
+                            primary="既存のSUIプロセスはありません"
+                            secondary="現在実行中のSUIプロセスは検出されませんでした"
+                          />
+                        </ListItem>
+                      )}
+                    </List>
+                  </Box>
+                </Paper>
+              )}
             </CardContent>
           </Card>
         </Grid>

--- a/src/renderer/src/pages/Dashboard.tsx
+++ b/src/renderer/src/pages/Dashboard.tsx
@@ -73,60 +73,52 @@ const Dashboard: React.FC = () => {
   const [logLevel, setLogLevel] = useState<string>('all')
   const [existingProcesses, setExistingProcesses] = useState<ExistingProcess[]>([])
   const [processExpanded, setProcessExpanded] = useState(false)
-  const [processMonitorInterval, setProcessMonitorInterval] = useState<NodeJS.Timeout | null>(null)
+  const processMonitorIntervalRef = useRef<NodeJS.Timeout | null>(null)
   const logListRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     // 初期状態の取得
     refreshStatus()
 
-    // リアルタイム更新のためのイベントリスナー設定
-    if (window.electronAPI) {
-      window.electronAPI.sui.onStatusChange((status) => {
-        setNetworkStatus(status)
-      })
+    // 初期ログロード
+    loadInitialLogs()
+    
+    // 既存プロセス検出
+    detectExistingProcesses()
+    
+    // プロセス監視の開始
+    startProcessMonitoring()
 
-      // リアルタイムログ更新
-      window.electronAPI.logs.onNewLog((newLog) => {
-        setLogs(prev => [newLog, ...prev].slice(0, 100)) // 最新100件を保持
-        
-        // 自動スクロール（新しいログが追加されたとき）
-        setTimeout(() => {
-          if (logListRef.current) {
-            logListRef.current.scrollTop = 0
-          }
-        }, 100)
-      })
-
-      // 初期ログロード
-      loadInitialLogs()
-      
-      // 既存プロセス検出
-      detectExistingProcesses()
-      
-      // プロセス監視の開始
-      startProcessMonitoring()
-    }
+    // 定期的な状態更新（5秒間隔）
+    const statusInterval = setInterval(() => {
+      refreshStatus()
+    }, 5000)
 
     // クリーンアップ
     return () => {
-      if (window.electronAPI) {
-        window.electronAPI.sui.removeAllListeners()
-        window.electronAPI.logs.removeAllListeners()
+      // プロセス監視の停止
+      if (processMonitorIntervalRef.current) {
+        clearInterval(processMonitorIntervalRef.current)
       }
       
-      // プロセス監視の停止
-      if (processMonitorInterval) {
-        clearInterval(processMonitorInterval)
-      }
+      // 状態更新の停止
+      clearInterval(statusInterval)
     }
   }, [])
 
   const loadInitialLogs = async () => {
     try {
       if (window.electronAPI) {
-        const logEntries = await window.electronAPI.logs.getLogs({ limit: 50 })
-        setLogs(logEntries)
+        const logEntries = await window.electronAPI.logs.getLogs()
+        // 型変換と最新50件の制限
+        const convertedLogs: LogEntry[] = logEntries
+          .slice(0, 50)
+          .map(log => ({
+            timestamp: log.timestamp,
+            level: log.level as 'info' | 'warn' | 'error' | 'debug',
+            message: log.message
+          }))
+        setLogs(convertedLogs)
       }
     } catch (error) {
       console.error('Failed to load initial logs:', error)
@@ -163,7 +155,7 @@ const Dashboard: React.FC = () => {
       }
     }, 5000)
     
-    setProcessMonitorInterval(interval)
+    processMonitorIntervalRef.current = interval
   }
 
 
@@ -208,11 +200,7 @@ const Dashboard: React.FC = () => {
     setMessage(null)
     try {
       if (window.electronAPI) {
-        const profiles = await window.electronAPI.config.getProfiles()
-        const activeProfile = profiles.find(p => p.active)
-        const port = activeProfile?.port || '9000'
-        
-        const result = await window.electronAPI.sui.verifyNetworkConnection(port)
+        const result = await window.electronAPI.sui.verifyNetworkConnection()
         setMessage(result.message)
         
         // 接続確認後に状態を更新

--- a/src/renderer/src/pages/Dashboard.tsx
+++ b/src/renderer/src/pages/Dashboard.tsx
@@ -84,7 +84,48 @@ const Dashboard: React.FC = () => {
     // 初期状態の取得
     refreshStatus()
 
+    // リアルタイム更新のためのイベントリスナー設定
+    if (window.electronAPI) {
+      // ネットワーク状態変更の監視
+      window.electronAPI.sui.onStatusChange((status) => {
+        setNetworkStatus(status)
+      })
 
+      // SUIサービスからのログ
+      window.electronAPI.sui.onLog((log) => {
+        const formattedLog = {
+          timestamp: new Date().toISOString(),
+          level: log.level as 'info' | 'warn' | 'error' | 'debug',
+          message: log.message,
+          source: 'SUI'
+        }
+        setLogs(prev => [formattedLog, ...prev].slice(0, 100))
+        
+        // 自動スクロール
+        setTimeout(() => {
+          if (logListRef.current) {
+            logListRef.current.scrollTop = 0
+          }
+        }, 100)
+      })
+
+      // リアルタイムログ更新
+      window.electronAPI.logs.onNewLog((newLog) => {
+        setLogs(prev => [newLog, ...prev].slice(0, 100)) // 最新100件を保持
+        
+        // 自動スクロール（新しいログが追加されたとき）
+        setTimeout(() => {
+          if (logListRef.current) {
+            logListRef.current.scrollTop = 0
+          }
+        }, 100)
+      })
+
+      // ログクリア時の処理
+      window.electronAPI.logs.onLogsCleared(() => {
+        setLogs([])
+      })
+    }
 
     // 初期ログロード
     loadInitialLogs()
@@ -105,6 +146,12 @@ const Dashboard: React.FC = () => {
 
     // クリーンアップ
     return () => {
+      // イベントリスナーのクリーンアップ
+      if (window.electronAPI) {
+        window.electronAPI.sui.removeAllListeners()
+        window.electronAPI.logs.removeAllListeners()
+      }
+      
       // プロセス監視の停止
       if (processMonitorIntervalRef.current) {
         clearInterval(processMonitorIntervalRef.current)
@@ -139,9 +186,17 @@ const Dashboard: React.FC = () => {
     }
   }
 
-  const refreshStatus = async (preserveRunningState = false) => {
+  const refreshStatus = async (preserveRunningState = false, updateFromRPC = false) => {
+    console.log(`refreshStatus呼び出し - preserveRunningState: ${preserveRunningState}, updateFromRPC: ${updateFromRPC}`)
     try {
       if (window.electronAPI) {
+        // RPC経由で最新情報を取得する場合
+        if (updateFromRPC) {
+          console.log('updateNetworkStatusを呼び出し中...')
+          await window.electronAPI.sui.updateNetworkStatus()
+          console.log('updateNetworkStatus呼び出し完了')
+        }
+        
         const status = await window.electronAPI.sui.getStatus()
         
         if (preserveRunningState) {
@@ -173,8 +228,8 @@ const Dashboard: React.FC = () => {
             running: true
           }))
           
-          // 詳細なネットワーク状態も取得（running状態を維持）
-          await refreshStatus(true)
+          // 詳細なネットワーク状態も取得（running状態を維持、RPC経由で更新）
+          await refreshStatus(true, true)
         } else if (!result.found || result.processes.length === 0) {
           // プロセスが見つからない場合は、SuiServiceの状態を確認してから決定
           const suiStatus = await window.electronAPI.sui.getStatus()
@@ -481,9 +536,11 @@ const Dashboard: React.FC = () => {
                 <Button
                   variant="outlined"
                   startIcon={<RefreshIcon />}
-                  onClick={() => {
-                    refreshStatus()
-                    detectExistingProcesses()
+                  onClick={async () => {
+                    console.log('状態更新ボタンクリック - updateNetworkStatusを呼び出します')
+                    await refreshStatus(false, true)
+                    await detectExistingProcesses()
+                    console.log('状態更新ボタン処理完了')
                   }}
                   disabled={false}
                 >

--- a/src/renderer/src/pages/Dashboard.tsx
+++ b/src/renderer/src/pages/Dashboard.tsx
@@ -72,7 +72,7 @@ const Dashboard: React.FC = () => {
   const [logExpanded, setLogExpanded] = useState(true)
   const [logLevel, setLogLevel] = useState<string>('all')
   const [existingProcesses, setExistingProcesses] = useState<ExistingProcess[]>([])
-  const [processsExpanded, setProcessExpanded] = useState(false)
+  const [processExpanded, setProcessExpanded] = useState(false)
   const [processMonitorInterval, setProcessMonitorInterval] = useState<NodeJS.Timeout | null>(null)
   const logListRef = useRef<HTMLDivElement>(null)
 
@@ -158,7 +158,7 @@ const Dashboard: React.FC = () => {
   const startProcessMonitoring = () => {
     // プロセス監視間隔を5秒に設定
     const interval = setInterval(() => {
-      if (processsExpanded) {
+      if (processExpanded) {
         detectExistingProcesses()
       }
     }, 5000)
@@ -466,15 +466,15 @@ const Dashboard: React.FC = () => {
                   )}
                   <Button
                     size="small"
-                    onClick={() => setProcessExpanded(!processsExpanded)}
-                    endIcon={processsExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                    onClick={() => setProcessExpanded(!processExpanded)}
+                    endIcon={processExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
                   >
-                    {processsExpanded ? '折りたたみ' : '展開'}
+                    {processExpanded ? '折りたたみ' : '展開'}
                   </Button>
                 </Box>
               </Box>
               
-              {processsExpanded && (
+              {processExpanded && (
                 <Paper variant="outlined" sx={{ maxHeight: 300, overflow: 'hidden' }}>
                   <Box sx={{ maxHeight: 300, overflowY: 'auto', backgroundColor: 'background.paper' }}>
                     <List dense>

--- a/src/renderer/src/pages/Dashboard.tsx
+++ b/src/renderer/src/pages/Dashboard.tsx
@@ -67,6 +67,9 @@ const Dashboard: React.FC = () => {
     transactions: 0,
   })
   const [loading, setLoading] = useState(false)
+  const [startingNetwork, setStartingNetwork] = useState(false)
+  const [stoppingNetwork, setStoppingNetwork] = useState(false)
+  const [networkStartupCompleted, setNetworkStartupCompleted] = useState(false)
   const [message, setMessage] = useState<string | null>(null)
   const [logs, setLogs] = useState<LogEntry[]>([])
   const [logExpanded, setLogExpanded] = useState(true)
@@ -74,31 +77,42 @@ const Dashboard: React.FC = () => {
   const [existingProcesses, setExistingProcesses] = useState<ExistingProcess[]>([])
   const [processExpanded, setProcessExpanded] = useState(false)
   const processMonitorIntervalRef = useRef<NodeJS.Timeout | null>(null)
+  const networkStartupMonitorRef = useRef<NodeJS.Timeout | null>(null)
   const logListRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     // 初期状態の取得
     refreshStatus()
 
+
+
     // 初期ログロード
     loadInitialLogs()
     
-    // 既存プロセス検出
+    // 既存プロセス検出（ネットワーク状態も同時に更新）
     detectExistingProcesses()
     
     // プロセス監視の開始
     startProcessMonitoring()
 
-    // 定期的な状態更新（5秒間隔）
-    const statusInterval = setInterval(() => {
-      refreshStatus()
-    }, 5000)
+    // 定期的な状態更新（3秒間隔に短縮）
+    const statusInterval = setInterval(async () => {
+      // 既存プロセス検出を先に実行してネットワーク状態を同期
+      await detectExistingProcesses()
+      // 既存プロセスの状態に応じて詳細情報を取得
+      // （detectExistingProcessesで既にrefreshStatusが適切に呼ばれている）
+    }, 3000)
 
     // クリーンアップ
     return () => {
       // プロセス監視の停止
       if (processMonitorIntervalRef.current) {
         clearInterval(processMonitorIntervalRef.current)
+      }
+      
+      // ネットワーク起動監視の停止
+      if (networkStartupMonitorRef.current) {
+        clearInterval(networkStartupMonitorRef.current)
       }
       
       // 状態更新の停止
@@ -125,11 +139,20 @@ const Dashboard: React.FC = () => {
     }
   }
 
-  const refreshStatus = async () => {
+  const refreshStatus = async (preserveRunningState = false) => {
     try {
       if (window.electronAPI) {
         const status = await window.electronAPI.sui.getStatus()
-        setNetworkStatus(status)
+        
+        if (preserveRunningState) {
+          // 既存プロセスで running: true が設定されている場合は維持
+          setNetworkStatus(prev => ({
+            ...status,
+            running: prev.running || status.running
+          }))
+        } else {
+          setNetworkStatus(status)
+        }
       }
     } catch (error) {
       console.error('Failed to get status:', error)
@@ -141,6 +164,25 @@ const Dashboard: React.FC = () => {
       if (window.electronAPI) {
         const result = await window.electronAPI.sui.detectExistingNetwork()
         setExistingProcesses(result.processes || [])
+        
+        // 既存プロセスが検知された場合、ネットワーク状態を更新
+        if (result.found && result.processes.length > 0) {
+          // ネットワーク状態を実行中に更新
+          setNetworkStatus(prev => ({
+            ...prev,
+            running: true
+          }))
+          
+          // 詳細なネットワーク状態も取得（running状態を維持）
+          await refreshStatus(true)
+        } else if (!result.found || result.processes.length === 0) {
+          // プロセスが見つからない場合は、SuiServiceの状態を確認してから決定
+          const suiStatus = await window.electronAPI.sui.getStatus()
+          setNetworkStatus(prev => ({
+            ...prev,
+            running: suiStatus.running // SuiServiceの判定を優先
+          }))
+        }
       }
     } catch (error) {
       console.error('Failed to detect existing processes:', error)
@@ -148,16 +190,68 @@ const Dashboard: React.FC = () => {
   }
 
   const startProcessMonitoring = () => {
-    // プロセス監視間隔を5秒に設定
+    // プロセス監視間隔を3秒に設定
     const interval = setInterval(() => {
       if (processExpanded) {
         detectExistingProcesses()
       }
-    }, 5000)
+    }, 3000)
     
     processMonitorIntervalRef.current = interval
   }
 
+  const startNetworkStartupMonitoring = () => {
+    // 既存の監視を停止
+    if (networkStartupMonitorRef.current) {
+      clearInterval(networkStartupMonitorRef.current)
+    }
+
+    let attempts = 0
+    const maxAttempts = 30 // 60秒間（2秒間隔 × 30回）
+
+    const monitorInterval = setInterval(async () => {
+      attempts++
+      
+      try {
+        // 既存プロセスを先に確認（これによりネットワーク状態も適切に更新される）
+        await detectExistingProcesses()
+        
+        // ネットワークが起動していれば監視を停止
+        // detectExistingProcessesが状態を適切に設定するので、その後の状態をチェック
+        setTimeout(() => {
+          setNetworkStatus(current => {
+            if (current.running) {
+              if (networkStartupMonitorRef.current) {
+                clearInterval(networkStartupMonitorRef.current)
+                networkStartupMonitorRef.current = null
+                setStartingNetwork(false)
+                setNetworkStartupCompleted(true)
+                setMessage('ネットワークが正常に起動しました')
+                
+                // 3秒後に完了状態をリセット
+                setTimeout(() => {
+                  setNetworkStartupCompleted(false)
+                }, 3000)
+              }
+            }
+            return current
+          })
+        }, 100)
+        
+        // 最大試行回数に達したら監視を停止
+        if (attempts >= maxAttempts) {
+          clearInterval(networkStartupMonitorRef.current!)
+          networkStartupMonitorRef.current = null
+          setStartingNetwork(false)
+          setMessage('ネットワーク起動の確認がタイムアウトしました')
+        }
+      } catch (error) {
+        console.error('Network startup monitoring error:', error)
+      }
+    }, 2000) // 2秒間隔に短縮
+
+    networkStartupMonitorRef.current = monitorInterval
+  }
 
   const handleKillProcess = async (pid: number) => {
     try {
@@ -238,40 +332,66 @@ const Dashboard: React.FC = () => {
   }
 
   const handleStart = async () => {
-    setLoading(true)
+    setStartingNetwork(true)
+    setNetworkStartupCompleted(false) // 完了状態をリセット
     setMessage(null)
     try {
       if (window.electronAPI) {
         const result = await window.electronAPI.sui.start()
         setMessage(result.message)
         if (result.success) {
-          // リアルタイム更新はイベントリスナーで処理される
-          console.log('SUI network start requested')
+          // ネットワーク起動後の監視を開始
+          startNetworkStartupMonitoring()
+          
+          // 即座に状態を更新（複数回実行）
+          setTimeout(async () => {
+            await refreshStatus()
+            await detectExistingProcesses()
+          }, 500)
+          
+          setTimeout(async () => {
+            await refreshStatus()
+            await detectExistingProcesses()
+          }, 1500)
+          
+          console.log('SUI network start requested and monitoring started')
+        } else {
+          // 起動に失敗した場合はstartingNetworkをfalseに
+          setStartingNetwork(false)
         }
       }
     } catch (error) {
       setMessage('ネットワークの起動に失敗しました')
-    } finally {
-      setLoading(false)
+      setStartingNetwork(false)
     }
   }
 
   const handleStop = async () => {
-    setLoading(true)
+    setStoppingNetwork(true)
+    setNetworkStartupCompleted(false) // 完了状態をリセット
     setMessage(null)
     try {
       if (window.electronAPI) {
+        // 起動監視を停止
+        if (networkStartupMonitorRef.current) {
+          clearInterval(networkStartupMonitorRef.current)
+          networkStartupMonitorRef.current = null
+        }
+        
         const result = await window.electronAPI.sui.stop()
         setMessage(result.message)
         if (result.success) {
-          // リアルタイム更新はイベントリスナーで処理される
+          // 即座に状態を更新
+          await refreshStatus()
+          await detectExistingProcesses()
+          
           console.log('SUI network stop requested')
         }
       }
     } catch (error) {
       setMessage('ネットワークの停止に失敗しました')
     } finally {
-      setLoading(false)
+      setStoppingNetwork(false)
     }
   }
 
@@ -319,7 +439,25 @@ const Dashboard: React.FC = () => {
                 />
               </Box>
               
-              {loading && <LinearProgress sx={{ mb: 2 }} />}
+              {(startingNetwork || stoppingNetwork) && (
+                <LinearProgress 
+                  sx={{ mb: 2 }} 
+                  color={startingNetwork ? "primary" : "secondary"}
+                />
+              )}
+              {networkStartupCompleted && (
+                <LinearProgress 
+                  variant="determinate" 
+                  value={100} 
+                  color="success" 
+                  sx={{ 
+                    mb: 2,
+                    '& .MuiLinearProgress-bar': {
+                      transition: 'transform 0.5s ease-in-out'
+                    }
+                  }} 
+                />
+              )}
               
               <Box display="flex" gap={2}>
                 <Button
@@ -327,7 +465,7 @@ const Dashboard: React.FC = () => {
                   color="primary"
                   startIcon={<StartIcon />}
                   onClick={handleStart}
-                  disabled={networkStatus.running || loading}
+                  disabled={networkStatus.running || startingNetwork}
                 >
                   ネットワーク開始
                 </Button>
@@ -336,7 +474,7 @@ const Dashboard: React.FC = () => {
                   color="error"
                   startIcon={<StopIcon />}
                   onClick={handleStop}
-                  disabled={!networkStatus.running || loading}
+                  disabled={!networkStatus.running || stoppingNetwork}
                 >
                   ネットワーク停止
                 </Button>
@@ -347,7 +485,7 @@ const Dashboard: React.FC = () => {
                     refreshStatus()
                     detectExistingProcesses()
                   }}
-                  disabled={loading}
+                  disabled={false}
                 >
                   状態更新
                 </Button>
@@ -356,7 +494,7 @@ const Dashboard: React.FC = () => {
                   color="info"
                   startIcon={<NetworkCheckIcon />}
                   onClick={handleVerifyConnection}
-                  disabled={loading}
+                  disabled={false}
                 >
                   接続確認
                 </Button>
@@ -365,7 +503,7 @@ const Dashboard: React.FC = () => {
                   color="warning"
                   startIcon={<SyncIcon />}
                   onClick={handleSyncWithExisting}
-                  disabled={loading}
+                  disabled={false}
                 >
                   既存と同期
                 </Button>
@@ -447,7 +585,7 @@ const Dashboard: React.FC = () => {
                       color="error"
                       startIcon={<DeleteSweepIcon />}
                       onClick={handleKillAllProcesses}
-                      disabled={loading}
+                      disabled={false}
                     >
                       すべて停止
                     </Button>
@@ -478,7 +616,7 @@ const Dashboard: React.FC = () => {
                                 color="error"
                                 startIcon={<DeleteIcon />}
                                 onClick={() => handleKillProcess(process.pid)}
-                                disabled={loading}
+                                disabled={false}
                               >
                                 停止
                               </Button>

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -8,6 +8,10 @@ export interface ElectronAPI {
       blockHeight: number
       transactions: number
     }>
+    updateNetworkStatus: (port?: string) => Promise<{
+      success: boolean
+      message?: string
+    }>
     checkInstallation: () => Promise<{
       installed: boolean
       version: string
@@ -66,6 +70,11 @@ export interface ElectronAPI {
       success: boolean
       message: string
     }>
+    
+    // イベントリスナー
+    onStatusChange: (callback: (status: any) => void) => void
+    onLog: (callback: (log: any) => void) => void
+    removeAllListeners: () => void
   }
   
   config: {
@@ -79,12 +88,18 @@ export interface ElectronAPI {
   }
 
   logs: {
-    getLogs: () => Promise<Array<{
+    getLogs: (filter?: any) => Promise<Array<{
       timestamp: string
       level: string
       message: string
     }>>
-    exportLogs: () => Promise<{ success: boolean; path?: string }>
+    exportLogs: (filePath?: string) => Promise<{ success: boolean; path?: string }>
+    clearLogs: () => Promise<{ success: boolean }>
+    
+    // イベントリスナー
+    onNewLog: (callback: (log: any) => void) => void
+    onLogsCleared: (callback: () => void) => void
+    removeAllListeners: () => void
   }
 
   system: {

--- a/src/renderer/src/types/electron.d.ts
+++ b/src/renderer/src/types/electron.d.ts
@@ -13,6 +13,59 @@ export interface ElectronAPI {
       version: string
       path: string
     }>
+    detectExistingNetwork: () => Promise<{
+      found: boolean
+      processes: Array<{
+        pid: number
+        command: string
+        port?: string
+        status?: {
+          pid: number
+          ppid: number
+          state: string
+          cpu: number
+          memory: number
+          time: string
+          command: string
+        }
+      }>
+    }>
+    getProcessStatus: (pid: number) => Promise<{
+      running: boolean
+      details?: {
+        pid: number
+        ppid: number
+        state: string
+        cpu: number
+        memory: number
+        time: string
+        command: string
+      }
+    }>
+    killProcess: (pid: number) => Promise<{
+      success: boolean
+      message: string
+    }>
+    killAllProcesses: () => Promise<{
+      success: boolean
+      message: string
+      results: Array<{
+        pid: number
+        success: boolean
+        message: string
+      }>
+    }>
+    verifyNetworkConnection: (port?: string) => Promise<{
+      connected: boolean
+      rpcReady: boolean
+      clientReady: boolean
+      message: string
+      details?: any
+    }>
+    syncWithExistingNetwork: () => Promise<{
+      success: boolean
+      message: string
+    }>
   }
   
   config: {

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "noEmit": false,
     "outDir": "dist",
+    "composite": true,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## 概要
既存のsuiネットワークとの同期機能追加

## 変更点
- 既存の起動ずみSUIプロセスの状況が更新されるようにする
- 「既存と同期」ボタン押下により起動済みのSUIネットワーク に接続できるようにする
- 「ネットワーク停止」ボタンにより同期したネットワークが停止できるようにする

## 関連Issue
なし

## 動作確認
- 画面の操作により、既存のSUIプロセスの状況が更新されることを確認
- 画面の操作により、「既存と同期」ボタン押下により起動済みのSUIネットワーク に接続できたことを確認
- 画面の操作により、「ネットワーク停止」ボタンにより同期したネットワークが停止されたことを確認

## その他
- ノード数、ブロック高、処理済みトランザクションの項目の更新が確認できなかったが、原因調査中

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive detection, monitoring, and management of existing SUI network processes directly from the dashboard, including viewing process details and resource usage.
  * Introduced the ability to stop individual or all SUI processes from the dashboard interface.
  * Added network connection verification and manual synchronization with existing SUI networks.
  * Enhanced dashboard UI with process lists, state indicators, and new control buttons for process and network management.
  * Implemented robust lifecycle management for SUI network processes including status polling, process termination, and network synchronization.
  * Extended IPC and Electron API with new methods to support process and network operations.
  * Expanded allowed Bash command permissions to include build commands.

* **Bug Fixes**
  * Improved error handling and status messaging for process and network operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->